### PR TITLE
agent.type implies subj.type

### DIFF
--- a/src/agent.cil
+++ b/src/agent.cil
@@ -8,6 +8,7 @@
 
        (typeattribute typeattr)
 
+       (call .subj.common.type (typeattr))
        (call .subj.useinteractivefd.type (typeattr))
 
        (block exec


### PR DESCRIPTION
This was already implied in the agent template but the behavior should be the
same when you decide to use plain type attributes instead