### PR TITLE
Rules needed to bound user.agent.type to user.type

### DIFF
--- a/src/agent/useragent/s/sudo.cil
+++ b/src/agent/useragent/s/sudo.cil
@@ -384,6 +384,7 @@
 (in user
 
     (call .sudo.client.type (subj))
+    (call .sudo.sigchld_subj_processes (subj))
     (call .sudo.visudo.client.type (subj)))
 
 (in user.agent

--- a/src/user.cil
+++ b/src/user.cil
@@ -66,6 +66,7 @@
 	   (typeattribute typeattr)
 
 	   (allow typeattr self (cap_userns (kill sys_ptrace)))
+	   (allow typeattr self (fd (use)))
 	   (allow typeattr self
 		  (process (getattr getrlimit getsched ptrace setfscreate
 				    setpgid setrlimit setsched)))


### PR DESCRIPTION
Allowing common users to pass file descriptors internally seems
fair, and the sudo sighchld access is both RBAC as well as RBACSEP
constrained, plus only applies to user.subj instead of .user.common.type