### PR TITLE
Allows firefox to read wf-recorder files from /tmp

### DIFF
--- a/src/agent/useragent/f/firefox.cil
+++ b/src/agent/useragent/f/firefox.cil
@@ -269,6 +269,9 @@
        (optional firefox_waypipe
 		 (call .waypipe.agent (subj exec.file)))
 
+       (optional firefox_wfrecorder
+		 (call .wfrecorder.tmp.read_file_files (subj)))
+
        (block common
 
 	      (macro type ((type ARG1))


### PR DESCRIPTION
So that I can record in memory instead of using non-volatile storage,
and still be able to use firefox to upload the file to some web service.