### PR TITLE
Firefox watches /tmp

### DIFF
--- a/src/agent/useragent/f/firefox.cil
+++ b/src/agent/useragent/f/firefox.cil
@@ -236,6 +236,7 @@
        (call .themes.data.read_file_pattern.type (subj))
 
        (call .tmp.deletename_file_dirs (subj))
+       (call .tmp.watch_file_dirs (subj))
 
        (call .user.dbus.nameclient.type (subj))
 

--- a/src/file/tmpfile.cil
+++ b/src/file/tmpfile.cil
@@ -32,6 +32,9 @@
 	   (call .var.file_type_transition
 		 (ARG1 file dir "tmp")))
 
+    (macro watch_file_dirs ((type ARG1))
+	   (allow ARG1 file (dir (watch))))
+
     (blockinherit .file.tmp.template)
 
     (call .mount.mountpoint.type (file))


### PR DESCRIPTION
Sometimes I upload files from /tmp (using Ctrl-L in file-chooser
dialog to specify the path to the file) and this triggers "gmain"
watch request