### PR TITLE
Related to user sandbox

### DIFF
--- a/src/agent/misc/systemd/usersystemd.cil
+++ b/src/agent/misc/systemd/usersystemd.cil
@@ -409,6 +409,8 @@
 	   (call .user.exec_home_subj_type_transition (subj))
 	   (call .user.exec_subj_type_transition (subj))
 
+	   (call .user.home.readwriteinherited_file_files (subj))
+
 	   (call .user.home.conf.create_file_dir_pattern.type (subj))
 
 	   (call .user.open_ptytermdev_chr_files (subj))

--- a/src/agent/misc/systemd/usersystemdrun.cil
+++ b/src/agent/misc/systemd/usersystemdrun.cil
@@ -9,6 +9,8 @@
 
 (in user.dbus
 
+    (call .user.home.readwriteinherited_file_files (subj))
+
     (call .user.systemd.run.pipe.client.type (subj)))
 
 (in user.systemd.run
@@ -71,6 +73,8 @@
     (call .user.exec_home_subj_type_transition (subj))
 
     (call .user.devpts_fs_type_transition_ptytermdev (subj))
+
+    (call .user.home.readwriteinherited_file_files (subj))
 
     (call .user.shell_exec_subj_type_transition (subj))
 


### PR DESCRIPTION
To make inherited read/write access to user.home.file type files
possible for user.sandbox.subj the file descriptor is passed from
user.systemd.run to user.systemd via user.dbus (or something along
those lines). Gist is that stuff like > >> < etc only works with these rules.