### PR TITLE
Redo the systemd-run --user --pipe file handling

### DIFF
--- a/src/agent/misc/systemd/systemdrun.cil
+++ b/src/agent/misc/systemd/systemdrun.cil
@@ -30,6 +30,8 @@
 
     (call common.type (subj))
 
+    (call pipe.file.readwriteinherited_all_files (subj))
+
     (call service.transition_all_processes (subj))
 
     (call service.exec.mapexecute_all_files (subj))
@@ -129,11 +131,23 @@
 
 		  (typeattribute typeattr)
 
+		  (call file.readwriteinherited_all_files (typeattr))
+
 		  (call pipe.readwriteinherited_all_fifo_files (typeattr))
 		  (call pipe.use_all_fds (typeattr))
 
 		  (call .user.termdev.readwriteinherited_all_chr_files
-			(typeattr))))
+			(typeattr)))
+
+	   (block file
+
+		  (macro readwriteinherited_all_files ((type ARG1))
+			 (allow ARG1 typeattr readwriteinherited_file))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (typeattribute typeattr)))
 
     (block service
 

--- a/src/agent/misc/systemd/usersystemd.cil
+++ b/src/agent/misc/systemd/usersystemd.cil
@@ -409,8 +409,6 @@
 	   (call .user.exec_home_subj_type_transition (subj))
 	   (call .user.exec_subj_type_transition (subj))
 
-	   (call .user.home.readwriteinherited_file_files (subj))
-
 	   (call .user.home.conf.create_file_dir_pattern.type (subj))
 
 	   (call .user.open_ptytermdev_chr_files (subj))

--- a/src/agent/misc/systemd/usersystemdrun.cil
+++ b/src/agent/misc/systemd/usersystemdrun.cil
@@ -9,9 +9,11 @@
 
 (in user.dbus
 
-    (call .user.home.readwriteinherited_file_files (subj))
-
     (call .user.systemd.run.pipe.client.type (subj)))
+
+(in user.home
+
+    (call .user.systemd.run.pipe.file.type (file)))
 
 (in user.systemd.run
 
@@ -43,6 +45,8 @@
     (roleattribute roleattr)
     (roletype roleattr subj)
 
+    (call pipe.file.readwriteinherited_all_files (subj))
+
     (call service.transition_all_processes (subj))
 
     (call service.exec.mapexecute_all_files (subj))
@@ -73,8 +77,6 @@
     (call .user.exec_home_subj_type_transition (subj))
 
     (call .user.devpts_fs_type_transition_ptytermdev (subj))
-
-    (call .user.home.readwriteinherited_file_files (subj))
 
     (call .user.shell_exec_subj_type_transition (subj))
 
@@ -108,11 +110,23 @@
 
 		  (typeattribute typeattr)
 
+		  (call file.readwriteinherited_all_files (typeattr))
+
 		  (call pipe.readwriteinherited_all_fifo_files (typeattr))
 		  (call pipe.use_all_fds (typeattr))
 
 		  (call .user.termdev.readwriteinherited_all_chr_files
-			(typeattr))))
+			(typeattr)))
+
+	   (block file
+
+		  (macro readwriteinherited_all_files ((type ARG1))
+			 (allow ARG1 typeattr readwriteinherited_file))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (typeattribute typeattr)))
 
     (block service
 
@@ -146,6 +160,10 @@
 			 (typeattributeset typeattr ARG1))
 
 		  (typeattribute typeattr))))
+
+(in user.tmp
+
+    (call .user.systemd.run.pipe.file.type (file)))
 
 (in wheel
 

--- a/src/agent/useragent/u/usersandbox.cil
+++ b/src/agent/useragent/u/usersandbox.cil
@@ -171,8 +171,6 @@
 			 (type subj)
 			 (typebounds .user.subj subj)
 
-			 (call .user.home.readwriteinherited_file_files (subj))
-
 			 (call .user.sandbox.agent.type (subj))
 
 			 (call .user.systemd.run.pipe.client.type (subj))


### PR DESCRIPTION
Create a user.systemd.run.pipe.file.typeattr that file types can be
associated with so that their file descriptors can be passed to
user.systemd.run.pipe.client.typeattr associated processes

Also allow the user sandbox to read/write inherited user.tmp.file files

Implement similar for systemd-run --system

Files associated with systemd.run.pipe.file.typeattr can be passed to
members of systemd.run.pipe.client.typeattr