### PR TITLE
usersandbox: remove some redundants

### DIFF
--- a/src/agent/useragent/u/usersandbox.cil
+++ b/src/agent/useragent/u/usersandbox.cil
@@ -103,8 +103,6 @@
 		  (call .node.read_sysfile_files (typeattr))
 		  (call .node.search_sysfile_dirs (typeattr))
 
-		  (call .ns.read_fs_pattern.type (typeattr))
-
 		  (call .nss.passwdgroup.type (typeattr))
 
 		  (call .osrelease.read_sysctlfile_files (typeattr))
@@ -149,8 +147,6 @@
 		  (call .uptime.read_procfile_files (typeattr))
 
 		  (call .user.agent.type (typeattr))
-
-		  (call .user.home.search_file_pattern.type (typeattr))
 
 		  (call .utmp.run.read_file_files (typeattr))
 


### PR DESCRIPTION
traversing user.home.file is implied with user.agent and access to
ns.fs is not needed as it cannot any other processes