### PR TITLE
usersystemdrun: remove redundant rule

### DIFF
--- a/src/agent/misc/systemd/usersystemdrun.cil
+++ b/src/agent/misc/systemd/usersystemdrun.cil
@@ -113,10 +113,7 @@
 		  (call file.readwriteinherited_all_files (typeattr))
 
 		  (call pipe.readwriteinherited_all_fifo_files (typeattr))
-		  (call pipe.use_all_fds (typeattr))
-
-		  (call .user.termdev.readwriteinherited_all_chr_files
-			(typeattr)))
+		  (call pipe.use_all_fds (typeattr)))
 
 	   (block file
 


### PR DESCRIPTION
pipe clients are user agents and user agents already have this access