### PR TITLE
pipewire and mpg123 traverse /var/lib

### DIFF
--- a/src/agent/hybridagent/d/dracut.cil
+++ b/src/agent/hybridagent/d/dracut.cil
@@ -21,6 +21,8 @@
 
        (call .caplastcap.read_sysctlfile_pattern.type (subj))
 
+       (call .cgroup.getattr_fs_pattern.type (subj))
+
        (call .class.traverse_sysfile_pattern.type (subj))
 
        (call .cmdline.read_procfile_files (subj))

--- a/src/agent/hybridagent/m/mpg123.cil
+++ b/src/agent/hybridagent/m/mpg123.cil
@@ -61,6 +61,8 @@
 
        (call .snd.readwrite_nodedev_chr_files (subj))
 
+       (call .state.search_file_pattern.type (subj))
+
        (block exec
 
 	      (filecon "/usr/bin/mpg123" file file_context)

--- a/src/agent/useragent/p/pipewire.cil
+++ b/src/agent/useragent/p/pipewire.cil
@@ -90,6 +90,8 @@
 
 	      (call .selinux.linked.type (typeattr))
 
+	      (call .state.search_file_pattern.type (typeattr))
+
 	      (call .systemd.journal.relay_msgs.type (typeattr))
 
 	      (call .user.home.conf.search_file_dirs (typeattr)))


### PR DESCRIPTION
this seems to be part of some pattern (maybe nss related?)

Signed-off-by: Dominick Grift <dominick.grift@defensec.nl>