### PR TITLE
systemd-fsck: allow it to determine that fsck.btrfs exists

### DIFF
--- a/src/agent/hybridagent/b/btrfsprogs.cil
+++ b/src/agent/hybridagent/b/btrfsprogs.cil
@@ -102,6 +102,10 @@
 
     (call .btrfsprogs.subj_type_transition (subj)))
 
+(in systemd.fsck
+
+    (call .btrfsprogs.subj_type_transition (subj)))
+
 (in systemd.sysusers
 
     (call .btrfsprogs.subj_type_transition (subj)))

--- a/src/agent/hybridagent/d/dosfstools.cil
+++ b/src/agent/hybridagent/d/dosfstools.cil
@@ -35,6 +35,10 @@
 
     (call .dosfstools.subj_type_transition (subj)))
 
+(in systemd.fsck
+
+    (call .dosfstools.subj_type_transition (subj)))
+
 (in systemd.sysusers
 
     (call .dosfstools.subj_type_transition (subj)))

--- a/src/agent/hybridagent/e/e2fsprogs.cil
+++ b/src/agent/hybridagent/e/e2fsprogs.cil
@@ -126,6 +126,10 @@
 
     (call .e2fsprogs.subj_type_transition (subj)))
 
+(in systemd.fsck
+
+    (call .e2fsprogs.subj_type_transition (subj)))
+
 (in systemd.sysusers
 
     (call .e2fsprogs.subj_type_transition (subj)))

--- a/src/agent/misc/systemd/systemdfsck.cil
+++ b/src/agent/misc/systemd/systemdfsck.cil
@@ -27,8 +27,6 @@
     (call .devices.read_sysfile_files (subj))
     (call .devices.traverse_sysfile_pattern.type (subj))
 
-    (call .e2fsprogs.subj_type_transition (subj))
-
     (call .fsck.subj_type_transition (subj))
 
     (call .gcrypt.conf.read_file_pattern.type (subj))


### PR DESCRIPTION
actually just allow it to run it (also fsck.ext and fsck.dos) but move
the rules to the appropriate modules for modularity