### PR TITLE
nspawn priv container take 2

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -200,6 +200,9 @@
 
     (call .e2fsprogs.subj_type_transition (subj))
 
+    ;; for privcontainer fd passing
+    (call .file.except.readwriteinherited_all_files (subj))
+
     (call .fs.mounton_sysfile_dirs (subj))
 
     (call .fsck.subj_type_transition (subj))


### PR DESCRIPTION
in the previous commit i tried to allow stuff like "privcontainer
--console=pipe cat </etc/virc" but that fd is passed to the container
via the nspawn container manager itself as well...
