### PR TITLE
for systemd-run --pipe </etc/virc

### DIFF
--- a/src/agent/misc/systemd.cil
+++ b/src/agent/misc/systemd.cil
@@ -1542,7 +1542,8 @@
 
 (in dbus
 
-    (call .sys.tmpfs.readwriteinherited_file_files (subj)))
+    ;; for systemd-run --pipe and machinectl
+    (call .file.except.readwriteinherited_all_files (subj)))
 
 (in dev
 

--- a/src/agent/misc/systemd/systemdmachine.cil
+++ b/src/agent/misc/systemd/systemdmachine.cil
@@ -5,13 +5,10 @@
 
     (call .ptmx.readwriteinherited_nodedev_chr_files (subj))
 
-    (call .sys.home.readinherited_file_files (subj))
-
     (call .systemd.machine.readwriteinherited_ptytermdev_chr_files (subj))
 
-    (call .systemd.nspawn.container.obj.readwriteinherited_all_chr_files (subj))
-
-    (call .user.home.readinherited_file_files (subj)))
+    (call .systemd.nspawn.container.obj.readwriteinherited_all_chr_files
+	  (subj)))
 
 (in file.unconfined
 


### PR DESCRIPTION
the fd gets passed via dbus, this is also a thing with machinectl so i
just replaced the existing rules which were not comprehensive enough
for this functionality
