### PR TITLE
sysagent: allow sysagents to also write sys.user subj fifo files

### DIFF
--- a/src/agent/sysagent.cil
+++ b/src/agent/sysagent.cil
@@ -19,7 +19,7 @@
 
 	   (call .agent.type (typeattr))
 
-	   (call .sys.user.readinherited_subj_fifo_files (typeattr))
+	   (call .sys.user.readwriteinherited_subj_fifo_files (typeattr))
 	   (call .sys.user.use_subj_fds (typeattr))
 
 	   ;; emergency shell


### PR DESCRIPTION
the write is for use with systemd-run --pipe , because sys.user pipe gets
passed via dbus (which is a sys.agent).
