### PR TITLE
visudo: should only be run as root ...

### DIFF
--- a/src/agent/useragent/s/sudo.cil
+++ b/src/agent/useragent/s/sudo.cil
@@ -293,7 +293,7 @@
 
        (block visudo
 
-	      (blockinherit .user.agent.template)
+	      (blockinherit .sys.agent.template)
 
 	      (allow subj self (capability (dac_read_search dac_override)))
 
@@ -384,8 +384,7 @@
 (in user
 
     (call .sudo.client.type (subj))
-    (call .sudo.sigchld_subj_processes (subj))
-    (call .sudo.visudo.client.type (subj)))
+    (call .sudo.sigchld_subj_processes (subj)))
 
 (in user.agent
 


### PR DESCRIPTION
... so it is more like a sys.agent than a user.agent (it writes to sys
terminal and is associated with a privilege role)
