### PR TITLE
shadowutils: these arent hybrids

### DIFF
--- a/src/agent/misc/shadowutils/chage.cil
+++ b/src/agent/misc/shadowutils/chage.cil
@@ -6,7 +6,8 @@
        (blockinherit .hybrid.agent.template)
 
        (allow subj self
-	      (capability (audit_write dac_override dac_read_search sys_chroot)))
+	      (capability (audit_write dac_override dac_read_search
+				       sys_chroot)))
        (allow subj self (process (setfscreate)))
        (allow subj self create_netlink_audit_socket)
        (allow subj self create_unix_dgram_socket)

--- a/src/agent/misc/shadowutils/chpasswd.cil
+++ b/src/agent/misc/shadowutils/chpasswd.cil
@@ -3,10 +3,11 @@
 
 (block chpasswd
 
-       (blockinherit .hybrid.agent.template)
+       (blockinherit .sys.agent.template)
 
        (allow subj self
-	      (capability (audit_write dac_override dac_read_search sys_chroot)))
+	      (capability (audit_write dac_override dac_read_search
+				       sys_chroot)))
        (allow subj self (process (setfscreate)))
        (allow subj self create_netlink_audit_socket)
        (allow subj self (netlink_audit_socket (nlmsg_relay)))

--- a/src/agent/misc/shadowutils/groupadd.cil
+++ b/src/agent/misc/shadowutils/groupadd.cil
@@ -3,7 +3,7 @@
 
 (block groupadd
 
-       (blockinherit .hybrid.agent.template)
+       (blockinherit .sys.agent.template)
 
        (allow subj self
 	      (capability (audit_write chown dac_override dac_read_search fsetid

--- a/src/agent/misc/shadowutils/useradd.cil
+++ b/src/agent/misc/shadowutils/useradd.cil
@@ -6,7 +6,7 @@
 
 (block useradd
 
-       (blockinherit .hybrid.agent.template)
+       (blockinherit .sys.agent.template)
 
        (allow subj self
 	      (capability (audit_write chown dac_override dac_read_search fowner

--- a/src/agent/misc/shadowutils/vipw.cil
+++ b/src/agent/misc/shadowutils/vipw.cil
@@ -3,7 +3,7 @@
 
 (block vipw
 
-       (blockinherit .hybrid.agent.template)
+       (blockinherit .sys.agent.template)
 
        (allow subj self (capability (chown dac_override dac_read_search)))
        (allow subj self (process (setfscreate setpgid)))


### PR DESCRIPTION
these need root and so theyre sys.agent in dssp5

roles with access to root are either sys.role or privileged roles and
privileged roles are considered system role.

either way you look at it, unprivileged user roles have no business
with these
