### PR TITLE
sudo: this does not make sense

### DIFF
--- a/src/agent/useragent/s/sudo.cil
+++ b/src/agent/useragent/s/sudo.cil
@@ -383,14 +383,13 @@
 
     (filecon "/usr/bin/sudo/sesh" file file_context))
 
-(in user
-
-    (call .sudo.client.type (subj))
-    (call .sudo.sigchld_subj_processes (subj)))
-
-(in user.agent
+(in sys.agent
 
     (call .sudo.sigchld_subj_processes (typeattr)))
+
+(in user
+
+    (call .sudo.client.type (subj)))
 
 (in user.priv
 


### PR DESCRIPTION
1. sudo can only transition to privileged roles/types, so the caller is
usually not a child of sudo
2. user.agents are to only be associated with unprivileged roles and
so unless they are hybrid they are usually not a child of sudo
