### PR TITLE
polkit/dbus: this is a bit of a compromise

### DIFF
--- a/src/agent/misc/dbus/dbus.cil
+++ b/src/agent/misc/dbus/dbus.cil
@@ -30,7 +30,12 @@
        (call .sys.status_system (subj))
 
        (call .systemd.notify.type (subj))
+
        (call .systemd.sessions.run.writeinherited_file_fifo_files (subj))
+
+       (call .systemd.unit.start_file_services (subj))
+       (call .systemd.unit.status_file_services (subj))
+       (call .systemd.unit.stop_file_services (subj))
 
        (call .systemd.inhibit.run.writeinherited_file_fifo_files (subj))
 

--- a/src/agent/sysagent/p/polkit.cil
+++ b/src/agent/sysagent/p/polkit.cil
@@ -59,6 +59,7 @@
        (call .subj.common.read_all_states (subj))
 
        (call .sys.read_subj_states (subj))
+       (call .sys.sendmsg_subj_dbus.type (subj))
 
        (call .sys.user.read_subj_states (subj))
        (call .sys.user.sendmsg_subj_dbus.type (subj))


### PR DESCRIPTION
this is to make unconfined dbus activated services, and unconfined
polkit client services work,

I encountered this with fwupd (which i do not target) fwupd is a
system service that is both dbus activated as well as a polkit client
