### PR TITLE
Revert "irssi: libsystemd (nss_systemd) probably pulled in this libselinux"

### DIFF
--- a/src/agent/useragent/i/irssi.cil
+++ b/src/agent/useragent/i/irssi.cil
@@ -63,6 +63,8 @@
 
        (call .random.read_nodedev_chr_files (subj))
 
+       (call .selinux.linked.type (subj))
+
        (call .terminfo.read_file_pattern.type (subj))
 
        (call .user.exec_subj_type_transition (subj))


### PR DESCRIPTION
interestingly irssi still wants libselinux, not sure what to make of this.

This reverts commit b6231c3c8aa4622c6565efd2ec1f6cd91d97476e.
