### PR TITLE
systemdnspawncontainer: dontaudit remount selinuxfs

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -655,6 +655,7 @@
 		  (call .procfile.read_all_files (typeattr))
 		  (call .procfile.read_all_lnk_files (typeattr))
 
+		  (call .selinux.dontaudit_remount_fs (typeattr))
 		  (call .selinux.getattr_fs (typeattr))
 		  (call .selinux.list_fs_dirs (typeattr))
 		  (call .selinux.read_fs_files (typeattr))

--- a/src/fs/noseclabelfs/selinuxnoseclabelfs.cil
+++ b/src/fs/noseclabelfs/selinuxnoseclabelfs.cil
@@ -8,6 +8,9 @@
 
     (genfscon "selinuxfs" "/" fs_context)
 
+    (macro dontaudit_remount_fs ((type ARG1))
+	   (dontaudit ARG1 fs (filesystem (remount))))
+
     (macro map_fs_files ((type ARG1))
 	   (allow ARG1 fs (file (map))))
 


### PR DESCRIPTION
as of 249 the ProtectSystem=strict tunable causes selinuxfs remounts
blocking this seems to not cause any issues and the mount options stay
the same anyway
