### PR TITLE
systemd-nspawn: add conditional read-only support for --bind-user=

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -390,7 +390,6 @@
 	   (call .net.port.nameconnect_all_tcp_sockets (subj))
 	   (call .net.sendto_nodes (subj))
 
-	   (call .rbacsep.constrained.type (subj))
 	   (call .rbacsep.readstatetarget.type (subj))
 
 	   (optional systemdnspawn_invalidassociationsboolfile

--- a/src/selinux/booleanfile/systemdnspawnbinduserbooleanfile.cil
+++ b/src/selinux/booleanfile/systemdnspawnbinduserbooleanfile.cil
@@ -1,0 +1,26 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(tunable systemdnspawn_bind_users false)
+
+(tunableif systemdnspawn_bind_users
+	   (true
+
+	    (call .logindefs.read_file_files (.systemd.nspawn.subj))
+
+	    (call .shadow.read.type (.systemd.nspawn.subj))
+	    (call .shadow.read_file_files (.systemd.nspawn.subj))
+
+	    (call .file.user.home.read_all_pattern.type
+		  (.systemd.nspawn.container.subj)))
+
+	   (false
+
+	    (call .rbacsep.constrained.type (.systemd.nspawn.container.subj))))
+
+(block systemdnspawn_bind_peers
+
+       (genfscon "selinuxfs" "/booleans/systemdnspawn_bind_users"
+		 booleanfile_context)
+
+       (blockinherit .booleanfile.template))


### PR DESCRIPTION
this feature was introduced with 249, it requires editing nsswitch.conf in
container where shadow and gshadow need systemd nss.

i made this read-only and it only applies to the default
systemd.nspawn.container.subj because otherwise you might get into
role/id issues as nspawn runs with sys.id:sys.role

obviously this is a security risk as nspawn can now effectively read
shadow and root processes in the container can read the users shadow password.
