### PR TITLE
systemd nspawn bind users: change of plan

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -394,6 +394,7 @@
 	   (call .net.port.nameconnect_all_tcp_sockets (subj))
 	   (call .net.sendto_nodes (subj))
 
+	   (call .rbacsep.constrained.type (subj))
 	   (call .rbacsep.readstatetarget.type (subj))
 
 	   (optional systemdnspawn_invalidassociationsboolfile

--- a/src/selinux/booleanfile/systemdnspawnbinduserbooleanfile.cil
+++ b/src/selinux/booleanfile/systemdnspawnbinduserbooleanfile.cil
@@ -6,15 +6,17 @@
 (tunableif systemdnspawn_bind_users
 	   (true
 
-	    (call .file.user.home.list_all_dirs
+	    (call .file.user.home.manage_all_dirs
 		  (.systemd.nspawn.container.subj))
-	    (call .file.user.home.read_all_fifo_files
+	    (call .file.user.home.manage_all_fifo_files
 		  (.systemd.nspawn.container.subj))
-	    (call .file.user.home.read_all_files
+	    (call .file.user.home.manage_all_files
 		  (.systemd.nspawn.container.subj))
-	    (call .file.user.home.read_all_lnk_files
+	    (call .file.user.home.manage_all_lnk_files
 		  (.systemd.nspawn.container.subj))
-	    (call .file.user.home.read_all_sock_files
+	    (call .file.user.home.manage_all_sock_files
+		  (.systemd.nspawn.container.subj))
+	    (call .file.user.home.map_all_files
 		  (.systemd.nspawn.container.subj))
 
 	    (call .home.read_file_lnk_files (.systemd.nspawn.subj))


### PR DESCRIPTION
only support this for sys.user.id users, and then give it manage
access instead of read-only
