### PR TITLE
make sys.agents useinteractivefd type

### DIFF
--- a/src/agent.cil
+++ b/src/agent.cil
@@ -10,6 +10,8 @@
 
        (call .subj.common.type (typeattr))
 
+       (call .subj.useinteractivefd.type (typeattr))
+
        (block exec
 
 	      (macro dontaudit_auditaccess_all_files ((type ARG1))

--- a/src/agent/misc/dbus/dbus.cil
+++ b/src/agent/misc/dbus/dbus.cil
@@ -29,8 +29,6 @@
        (call .sys.sendmsg_subj_dbus.type (subj))
        (call .sys.status_system (subj))
 
-       (call .systemd.login.use_subj_fds (subj))
-
        (call .systemd.notify.type (subj))
 
        (call .systemd.sessions.run.writeinherited_file_fifo_files (subj))

--- a/src/agent/misc/pam.cil
+++ b/src/agent/misc/pam.cil
@@ -79,8 +79,6 @@
 	      (call .sys.user.link_subj_keyrings (typeattr))
 	      (call .sys.user.search_subj_keyrings (typeattr))
 
-	      (call .systemd.login.use_subj_fds (typeattr))
-
 	      (call .systemd.sessions.run.writeinherited_file_fifo_files
 		    (typeattr))
 

--- a/src/agent/misc/systemd/systemdmachine.cil
+++ b/src/agent/misc/systemd/systemdmachine.cil
@@ -6,7 +6,6 @@
     (call .ptmx.readwriteinherited_nodedev_chr_files (subj))
 
     (call .systemd.machine.readwriteinherited_ptytermdev_chr_files (subj))
-    (call .systemd.machine.use_subj_fds (subj))
 
     (call .systemd.nspawn.container.obj.readwriteinherited_all_chr_files
 	  (subj)))

--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -396,6 +396,7 @@
 
 	   (call .rbacsep.constrained.type (subj))
 	   (call .rbacsep.readstatetarget.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
 
 	   (optional systemdnspawn_invalidassociationsboolfile
 		     (call .invalidassociations.type (subj)))
@@ -665,6 +666,9 @@
 		  (call .selinux.read_fs_files (typeattr))
 
 		  (call .subj.type (typeattr))
+		  (call .subj.useinteractivefd.type (typeattr))
+
+		  (call .sudo.use_subj_fds (typeattr))
 
 		  (call .sys.dontaudit_search_subj_keyrings (typeattr))
 		  (call .sys.modulerequest_system (typeattr))
@@ -672,8 +676,6 @@
 		  (call .sysfile.list_all_dirs (typeattr))
 		  (call .sysfile.read_all_files (typeattr))
 		  (call .sysfile.read_all_lnk_files (typeattr))
-
-		  (call .systemd.machine.use_subj_fds (typeattr))
 
 		  (call .tmp.unmount_fs (typeattr))
 
@@ -799,8 +801,6 @@
 	   (call .net.port.namebind_all_udp_sockets (subj))
 	   (call .net.port.nameconnect_all_tcp_sockets (subj))
 	   (call .net.sendto_nodes (subj))
-
-	   (call .sudo.use_subj_fds (subj))
 
 	   (call .sys.readwriteinherited_subj_fifo_files (subj))
 	   (call .sys.use_subj_fds (subj))

--- a/src/agent/useragent.cil
+++ b/src/agent/useragent.cil
@@ -38,8 +38,6 @@
 
 	   (call .rbacsep.usefdsource.type (typeattr))
 
-	   (call .subj.useinteractivefd.type (typeattr))
-
 	   (block client
 
 		  (macro type ((type ARG1))


### PR DESCRIPTION
i can't really explain this but this is atleast needed when you login
as sys.user, then sudo to root, then runcon -t sys.subj and then run a
sys agent such as for example btrfs filesystem du

without this the sys agent can't use the pty fd

you should be able to run your nspawn containers from a shell so that
implies using sudo and interactive fds
