### PR TITLE
label unknown block and char in /dev dev.file

### DIFF
--- a/src/misc.cil
+++ b/src/misc.cil
@@ -107,6 +107,8 @@
 (in dev
 
     (filecon "/dev" dir file_context)
+    (filecon "/dev/.*" block file_context)
+    (filecon "/dev/.*" char file_context)
     (filecon "/dev/.*" dir file_context)
     (filecon "/dev/.*" file file_context)
     (filecon "/dev/.*" pipe file_context)


### PR DESCRIPTION
so that udev can relabelfrom

systemd relabels /dev before udev does and since systemd is
unconfined, it will relabel all unknown chars and blocks in /dev/ type
dev.file. then if for some reason the char or block gets a valid type
at runtime then udev will be able to apply the label

Signed-off-by: Dominick Grift <dominick.grift@defensec.nl>
