### PR TITLE
postfix.smtp: force it to bind to one of my gazillion ip6 addresses

### DIFF
--- a/src/agent/sysagent/p/postfix.cil
+++ b/src/agent/sysagent/p/postfix.cil
@@ -1039,6 +1039,8 @@
 	      (call master.agent (subj exec.file))
 	      (call master.unix_stream_connect_private (subj))
 
+	      (call .net.nodebind_netnode_tcp_sockets (subj))
+
 	      (call .nss.services.type (subj))
 
 	      (call .rbacsep.constrained.type (subj))


### PR DESCRIPTION
when sending emails
