### PR TITLE
kernelinstall: creates symlink in /boot as of linux 5.13

### DIFF
--- a/src/agent/misc/systemd/kernelinstall.cil
+++ b/src/agent/misc/systemd/kernelinstall.cil
@@ -15,7 +15,9 @@
        (call data.execute_file_files (subj))
 
        (call .boot.manage_file_files (subj))
+       (call .boot.manage_file_lnk_files (subj))
        (call .boot.readwrite_file_dirs (subj))
+       (call .boot.relabel_file_lnk_files (subj))
        (call .boot.relabelto_file_files (subj))
 
        (call .bootloader.boot.manage_file_files (subj))

--- a/src/file/bootfile.cil
+++ b/src/file/bootfile.cil
@@ -11,6 +11,7 @@
 		    (ARG1 file dir "boot")))
 
        (blockinherit .file.boot.template)
+       (blockinherit .file.macro_template_lnk_files)
 
        (call .mount.mountpoint.type (file)))
 
@@ -23,6 +24,7 @@
 
 	   (blockinherit file.all_macro_template_dirs)
 	   (blockinherit file.all_macro_template_files)
+	   (blockinherit file.all_macro_template_lnk_files)
 
 	   (typeattribute typeattr)
 


### PR DESCRIPTION
Uses restorecon (without -F) to reset its context.
/boot/symvers-5.13.1-300.fc34.x86_64.g
