### PR TITLE
systemd --user instances do the aws detection dance (at least try)

### DIFF
--- a/src/agent/misc/systemd/usersystemd.cil
+++ b/src/agent/misc/systemd/usersystemd.cil
@@ -313,6 +313,8 @@
 
 	   (call .file.user.unit.read_all_files (subj))
 
+	   (call .firmware.search_sysfile_pattern.type (subj))
+
 	   (call .fs.read_sysctlfile_files (subj))
 	   (call .fs.search_sysctlfile_pattern.type (subj))
 


### PR DESCRIPTION
eg. tries to read a firmware sys file that needs root
