### PR TITLE
portables

### DIFF
--- a/src/agent/misc/utillinux/mount.cil
+++ b/src/agent/misc/utillinux/mount.cil
@@ -9,6 +9,8 @@
 
        (call .mount.image.type (file))
 
+       (call .tmp.associate_fs (file))
+
        (call .xattr.associate_fs_pattern.type (file)))
 
 (block mount

--- a/src/file/runfile.cil
+++ b/src/file/runfile.cil
@@ -21,9 +21,7 @@
 
        (call .mount.mountpoint.type (file))
 
-       (call .root.associate_fs (file))
-
-       (call .xattr.associate_fs_pattern.type (file)))
+       (call .root.associate_fs (file)))
 
 (in file
 
@@ -46,6 +44,8 @@
 	   (call file.type (typeattr))
 
 	   (call .tmp.associate_fs (typeattr))
+
+	   (call .xattr.associate_fs_pattern.type (typeattr))
 
 	   (block base_template
 


### PR DESCRIPTION
- allow image.file to associate with tmp.fs
- runfile: allow all file.run to associate with xattr.fs
