### PR TITLE
systemd-portabled: portablectl detach image

### DIFF
--- a/src/agent/misc/systemd/systemdportable.cil
+++ b/src/agent/misc/systemd/systemdportable.cil
@@ -112,7 +112,7 @@
     (call .sys.sendmsg_subj_dbus.type (subj))
     (call .sys.status_system (subj))
 
-    (call .systemd.conf.search_file_pattern.type (subj))
+    (call .systemd.conf.deletename_file_dirs (subj))
 
     (call .systemd.journal.relay_msgs.type (subj))
 

--- a/src/agent/misc/systemd/systemdportablectl.cil
+++ b/src/agent/misc/systemd/systemdportablectl.cil
@@ -45,6 +45,7 @@
 	   (call .state.search_file_pattern.type (subj))
 
 	   (call .sys.reload_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
 
 	   (call .systemd.askpassword.client.type (subj))
 


### PR DESCRIPTION
not sure why this is happening ...

it remove_name dir "system.attached" type systemd.conf.file but
system.attached is type systemd.unit.file?
