### PR TITLE
coredump: this must be a leak

### DIFF
--- a/src/agent/misc/systemd/systemdcoredump.cil
+++ b/src/agent/misc/systemd/systemdcoredump.cil
@@ -39,7 +39,7 @@
 
     (call .cgroup.getattr_fs_pattern.type (subj))
 
-    (call .corepattern.writeinherited_sysctlfile_files (subj))
+    (call .corepattern.dontaudit_writeinherited_sysctlfile_files (subj))
 
     (call .crypto.read_sysctlfile_pattern.type (subj))
 

--- a/src/sys/procfile/sysctlfile/kernelsysctlfile/corepatternkernelsysctlfile.cil
+++ b/src/sys/procfile/sysctlfile/kernelsysctlfile/corepatternkernelsysctlfile.cil
@@ -5,6 +5,9 @@
 
        (genfscon "proc" "/sys/kernel/core_pattern" sysctlfile_context)
 
+       (macro dontaudit_writeinherited_sysctlfile_files ((type ARG1))
+	      (dontaudit ARG1 sysctlfile writeinherited_file))
+
        (macro getattr_sysctlfile_files ((type ARG1))
 	      (allow ARG1 sysctlfile (file (getattr))))
 


### PR DESCRIPTION
systemd-coredump@.service is configured with ProtectKernelTunables=yes
