### PR TITLE
httpd3

### DIFF
--- a/src/agent/sysagent/h/httpd.cil
+++ b/src/agent/sysagent/h/httpd.cil
@@ -84,8 +84,7 @@
        (call .exec.mapexecute_file_files (subj))
        (call .exec.read_file_files (subj))
 
-       ;; /usr/share/testpage
-       (call .data.dontaudit_read_file_lnk_files (subj))
+       (call .data.read_file_lnk_files (subj))
 
        (call .dos.getattr_fs_pattern.type (subj))
        (call .dos.manage_fs_pattern.type (subj))

--- a/src/agent/sysagent/p/phpfpm.cil
+++ b/src/agent/sysagent/p/phpfpm.cil
@@ -215,6 +215,8 @@
     (call .http.nameconnect_port_tcp_sockets (subj))
     (call .http.https.nameconnect_port_tcp_sockets (subj))
 
+    (call .mysql.nameconnect_port_tcp_sockets (subj))
+
     (call .net.nodebind_netnode_tcp_sockets (subj))
 
     (call .nss.hosts.type (subj))

--- a/src/net/portnet/unreservedportnet/m/mysqlunreservedport.cil
+++ b/src/net/portnet/unreservedportnet/m/mysqlunreservedport.cil
@@ -1,0 +1,28 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block mysql
+
+       (portcon "dccp" 3306 port_context)
+       (portcon "dccp" 33060 port_context)
+       (portcon "dccp" 33061 port_context)
+       (portcon "sctp" 3306 port_context)
+       (portcon "sctp" 33060 port_context)
+       (portcon "sctp" 33061 port_context)
+       (portcon "tcp" 3306 port_context)
+       (portcon "tcp" 33060 port_context)
+       (portcon "tcp" 33061 port_context)
+       (portcon "udp" 3306 port_context)
+       (portcon "udp" 33060 port_context)
+       (portcon "udp" 33061 port_context)
+
+       (blockinherit .net.port.unreserved.template)
+
+       (block admin
+
+	      (portcon "dccp" 33062 port_context)
+	      (portcon "sctp" 33062 port_context)
+	      (portcon "tcp" 33062 port_context)
+	      (portcon "udp" 33062 port_context)
+
+	      (blockinherit .net.port.unreserved.template)))


### PR DESCRIPTION
- httpd: allow it to read the /usr/share/testpage symlink
- adds mysql ports and allows the default phpfpm instance access
