### PR TITLE
mariadb make it "work" with systemd-portable default profile

### DIFF
--- a/src/agent/misc/mariadb/mariadbserver.cil
+++ b/src/agent/misc/mariadb/mariadbserver.cil
@@ -52,6 +52,7 @@
 
 	   (call unit.status_file_services (subj))
 
+	   (call utils.nnptransition_subj_processes (subj))
 	   (call utils.subj_type_transition (subj))
 
 	   (call .block.list_sysfile_dirs (subj))
@@ -262,6 +263,8 @@
 	   (call server.state.search_file_dirs (subj))
 	   (call server.state.setattr_file_dirs (subj))
 
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
 	   (call .exec.execute_file_files (subj))
 
 	   (call .file.conf.mariadb.read_all_files (subj))
@@ -271,6 +274,8 @@
 
 	   (call .nss.hosts.type (subj))
 	   (call .nss.passwdgroup.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
 
 	   (call .selinux.linked.type (subj))
 

--- a/src/agent/misc/systemd/systemdjournal.cil
+++ b/src/agent/misc/systemd/systemdjournal.cil
@@ -13,6 +13,7 @@
     (allow subj self
 	   (capability (audit_control chown dac_read_search dac_override fowner
 				      setgid setuid sys_admin)))
+    (dontaudit subj self (cap_userns (sys_ptrace)))
     (allow subj self (capability2 (syslog)))
     (allow subj self create_unix_dgram_socket)
     (allow subj self create_unix_stream_stream_socket)


### PR DESCRIPTION
These are the overrides:

[Service]
RuntimeDirectory=mariadb
LogsDirectory=mariadb
StateDirectory=mysql
BindPaths=/run

You would need mariadb (not mariadb-server) on the host.
You cannot use the mariadb-secure-installation script
You have to comment out: https://github.com/MariaDB/server/blob/57f14eab20ae2733eb341f3d293515a10a40bc48/scripts/mysql_install_db.sh#L476
