### PR TITLE
nspawn containers: /proc/sys is mounted r/o

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -632,10 +632,6 @@
 
 		  (call .hugetlb.getattr_fs (typeattr))
 
-		  (call .ipv4.write_sysctlfile_files (typeattr))
-
-		  (call .ipv6.write_sysctlfile_files (typeattr))
-
 		  (call .kcore.read.type (typeattr))
 
 		  (call .kernel.mounton_sysfile_dirs (typeattr))
@@ -651,8 +647,6 @@
 		  (call .mqueue.unmount_fs (typeattr))
 
 		  (call .mtrr.mounton_procfile_files (typeattr))
-
-		  (call .net.write_sysctlfile_files (typeattr))
 
 		  (call .ns.getattr_fs (typeattr))
 
@@ -677,6 +671,9 @@
 
 		  (call .sys.dontaudit_search_subj_keyrings (typeattr))
 		  (call .sys.modulerequest_system (typeattr))
+
+		  (call .sysctlfile.dontaudit_writeinherited_all_files
+			(typeattr))
 
 		  (call .sysfile.list_all_dirs (typeattr))
 		  (call .sysfile.read_all_files (typeattr))

--- a/src/sys/procfile/sysctlfile.cil
+++ b/src/sys/procfile/sysctlfile.cil
@@ -3,6 +3,9 @@
 
 (block sysctlfile
 
+       (macro dontaudit_writeinherited_all_files ((type ARG1))
+	      (dontaudit ARG1 typeattr (file (write))))
+
        (macro type ((type ARG1))
 	      (typeattributeset typeattr ARG1))
 


### PR DESCRIPTION
I should be able to silently block any write attempts to sysctl files
