### PR TITLE
nspawn container: allow generic container to write some net sysctl

### DIFF
--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -390,6 +390,9 @@
 
 	   (blockinherit template)
 
+	   (call .ipv4.write_sysctlfile_files (subj))
+	   (call .ipv6.write_sysctlfile_files (subj))
+
 	   (call .net.egress_netifs (subj))
 	   (call .net.nodebind_netnode_tcp_sockets (subj))
 	   (call .net.nodebind_netnode_udp_sockets (subj))
@@ -397,6 +400,8 @@
 	   (call .net.port.namebind_all_udp_sockets (subj))
 	   (call .net.port.nameconnect_all_tcp_sockets (subj))
 	   (call .net.sendto_nodes (subj))
+
+	   (call .net.write_sysctlfile_files (subj))
 
 	   (call .rbacsep.constrained.type (subj))
 	   (call .rbacsep.readstatetarget.type (subj))


### PR DESCRIPTION
/proc/sys/net is mounted r/w with unpriv containers but is mounted r/o
with priv containers
