### PR TITLE
misc.cil: deal with systemd

### DIFF
--- a/src/misc.cil
+++ b/src/misc.cil
@@ -607,6 +607,10 @@
 	   (call .tmp.fs_type_transition
 		 (ARG1 file ARG2 ARG3))))
 
+(in sys.unconfined
+
+    (allow typeattr subj (system (reboot reload start status stop))))
+
 (in tmp
 
     (filecon "/dev/shm" dir fs_context)


### PR DESCRIPTION
we have to declare the systemd specific system permissions but we
might not actually use systemd. in the case of fedora we do use
systemd so ensure that sys.unconfined can use the systemd specific
system permissions.
