### PR TITLE
misc.cil: deal with systemd

### DIFF
--- a/src/misc.cil
+++ b/src/misc.cil
@@ -65,6 +65,10 @@
 
     (neverallow not_typeattr .unknown.file (system (module_load))))
 
+(in sys.unconfined
+
+    (allow typeattr subj (system (reboot reload start status stop))))
+
 (in tmp
 
     (filecon "/dev/shm" dir ())


### PR DESCRIPTION
we have to declare the systemd specific system permissions but we
might not actually use systemd. in the case of fedora we do use
systemd so ensure that sys.unconfined can use the systemd specific
system permissions.
