### PR TITLE
osprober

### DIFF
--- a/src/agent/sysagent/o/osprober.cil
+++ b/src/agent/sysagent/o/osprober.cil
@@ -6,6 +6,7 @@
        (blockinherit .sys.agent.template)
 
        (allow subj self (capability (dac_read_search sys_admin)))
+       (allow subj self (process (setfscreate)))
 
        (call data.read_file_files (subj))
        (call data.search_file_dirs (subj))
@@ -13,6 +14,7 @@
        (call exec.execute_file_files (subj))
 
        (call state.manage_file_dirs (subj))
+       (call state.manage_file_files (subj))
        (call state.mounton_file_dirs (subj))
 
        (call tmp.manage_file_dirs (subj))
@@ -65,6 +67,10 @@
 
        (call .swaps.read_procfile_files (subj))
 
+       (call .sys.home.list_file_dirs (subj))
+
+       (call .sys.tmp.delete_file_files (subj))
+
        (call .systemd.udev.data.search_file_dirs (subj))
        (call .systemd.udev.subj_type_transition (subj))
 
@@ -76,11 +82,18 @@
 
        (call .user.home.list_file_dirs (subj))
 
+       (call .var.read_file_lnk_files (subj))
+
        (call .xattr.getattr_fs_pattern.type (subj))
        (call .xattr.mount_fs (subj))
        (call .xattr.unmount_fs (subj))
 
        (call .zram.list_sysfile_dirs (subj))
+
+       (optional osprober_systemdnspawn
+		 (call .systemd.nspawn.container.obj.read_all_files (subj))
+		 (call .systemd.nspawn.container.obj.read_all_lnk_files (subj))
+		 (call .systemd.nspawn.container.obj.search_all_dirs (subj)))
 
        (block data
 

--- a/src/agent/useragent/w/wfrecorder.cil
+++ b/src/agent/useragent/w/wfrecorder.cil
@@ -97,6 +97,8 @@
        (call .user.home.manage_file_files (subj))
        (call .user.home.readwrite_file_files (subj))
 
+       (call .v4l.readwrite_nodedev_chr_files (subj))
+
        (call .wlroots.client.type (subj))
 
        (block exec


### PR DESCRIPTION
- mako reads pixmaps data
- e2fsprogs: dumpe2fs nss passwdgroup
- bluez: wireplumber dbus chat
- adds ident unreserved port and allows emacs (erc) to tcp bind socket
- emacs send kill signals to user agent from emacs shell
- emacs: this is not redundant
- emacs: allow it to signall all user agents
- machinectl: machinectl shell mycontainer '/bin/id' > ~/test
- machinectl: this seems specific to emacs and buggy
- adds libcmrt conf file and allow wf-recorder to read it
- cryptsetup and sulogin loose ends
- mako dbus chats with emacs
- emacs for M-x shell
- machinectl: this is fluke
- mako: logs to journal
- firefox some stuff that surfaced when trying to watch olympic
- swaybg maps mime data files
- nspawn containers: /proc/sys is mounted r/o
- sysctlfile: use permission set
- nspawn container: allow generic container to write some net sysctl
- nspawn: allow generic container to write all net sysctl files
- qemu-img: libgcrypt client
- openssh: move to src/agent/misc
- osprober and wfrecorder rules
