### PR TITLE
user: removes duplicate user.roleattr

### DIFF
--- a/src/user.cil
+++ b/src/user.cil
@@ -6,21 +6,15 @@
     (macro dontaudit_open_subj_fifo_files ((type ARG1))
 	   (dontaudit ARG1 subj (fifo_file (open))))
 
-    (macro role ((role ARG1))
-	   (roleattributeset roleattr ARG1))
-
     (macro type ((type ARG1))
 	   (typeattributeset typeattr ARG1))
 
-    (roleattribute roleattr)
     (typeattribute typeattr)
 
     (blockinherit all_macro_template)
 
     ;; access to user agents is governed per-unpriv-role with rbac
     (call agent.client.type (subj))
-
-    (call .obj.role (roleattr))
 
     (call .ci.getattr_fs_pattern.type (subj))
     (call .ci.manage_fs_pattern.type (subj))
@@ -254,8 +248,6 @@
 	   (roleallow roleallow.roleattr role)
 
 	   (userrole userrole.userattr role)
-
-	   (call .user.role (role))
 
 	   (block roleallow
 

--- a/src/user/privuser.cil
+++ b/src/user/privuser.cil
@@ -25,6 +25,8 @@
 	   (call .cryptopol.data.read_file_files (typeattr))
 	   (call .cryptopol.data.search_file_pattern.type (typeattr))
 
+	   (call .obj.role (roleattr))
+
 	   (call .rbac.subjchangetarget.type (typeattr))
 
 	   (call .rbacsep.exempt.role (roleattr))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -31,6 +31,9 @@
 	   (call common.type (typeattr))
 
 	   (call .ibac.subjchangetarget.type (typeattr))
+
+	   (call .obj.role (roleattr))
+
 	   (call .rbac.subjchangetarget.type (typeattr))
 
 	   (call .rbacsep.usefdsource.type (typeattr))


### PR DESCRIPTION
it is a bit ugly but it should work since roles have to be either priv
or unpriv regardless
