### PR TITLE
user/unprivuser changes

### DIFF
--- a/src/user.cil
+++ b/src/user.cil
@@ -311,13 +311,4 @@
 
 	   (roleattribute roleattr)
 
-	   (roletype roleattr subj))
-
-    (block template
-
-	   (blockabstract template)
-
-	   (blockinherit .user.role_template)
-	   (blockinherit .user.subj_template)
-
-	   (call role (role))))
+	   (roletype roleattr subj)))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -72,7 +72,9 @@
 		  (blockinherit .user.id_template)
 		  (blockinherit .user.unpriv.role_template)
 
-		  (call userrole.user (id)))
+		  (call userrole.user (id))
+
+		  (call .user.role (role)))
 
 	   (block userrole
 


### PR DESCRIPTION
user.template is pointless because either a user is a priv user or an
unpriv user.

the user.unpriv.template is to be used with user.subj so authorize the role
