### PR TITLE
shadow

### DIFF
--- a/src/file/authfile/shadowauthfile.cil
+++ b/src/file/authfile/shadowauthfile.cil
@@ -41,8 +41,11 @@
 (in file.unconfined
 
     (call .shadow.conf_file_type_transition_file (typeattr "gshadow"))
+    (call .shadow.conf_file_type_transition_file (typeattr "gshadow-"))
     (call .shadow.conf_file_type_transition_file (typeattr "nshadow"))
+    (call .shadow.conf_file_type_transition_file (typeattr "nshadow-"))
     (call .shadow.conf_file_type_transition_file (typeattr "shadow"))
+    (call .shadow.conf_file_type_transition_file (typeattr "shadow-"))
     (call .shadow.db_file_type_transition_file (typeattr "shadow.db"))
     (call .shadow.db_file_type_transition_file (typeattr "shadow.tdb"))
 

--- a/src/file/misc/passwdfile.cil
+++ b/src/file/misc/passwdfile.cil
@@ -30,9 +30,13 @@
 (in file.unconfined
 
     (call .passwd.conf_file_type_transition_file (typeattr "group"))
+    (call .passwd.conf_file_type_transition_file (typeattr "group-"))
     (call .passwd.conf_file_type_transition_file (typeattr "passwd"))
+    (call .passwd.conf_file_type_transition_file (typeattr "passwd-"))
     (call .passwd.conf_file_type_transition_file (typeattr "subgid"))
+    (call .passwd.conf_file_type_transition_file (typeattr "subgid-"))
     (call .passwd.conf_file_type_transition_file (typeattr "subuid"))
+    (call .passwd.conf_file_type_transition_file (typeattr "subuid-"))
     (call .passwd.db_file_type_transition_file (typeattr "group.db"))
     (call .passwd.db_file_type_transition_file (typeattr "group.tdb"))
     (call .passwd.db_file_type_transition_file (typeattr "passwd.db"))


### PR DESCRIPTION
- osprober and wfrecorder rules
- sockets should be referenced from socketav
- misc.cil: fix redeclarations of some inputrc blocks
- fixes systemd.sleep redeclaration
- fstab: removes duplicate macro
- gitshelluser: removes duplicate macro
- user: removes duplicate user.roleattr
- user/unprivuser changes
- passwdfile and shadowauthfile automatic transitions
