### PR TITLE
devicemapper rw sem not of sys.user but of sys

### DIFF
--- a/src/agent/sysagent/d/devicemapper.cil
+++ b/src/agent/sysagent/d/devicemapper.cil
@@ -22,8 +22,7 @@
        (call .selinux.linked.type (subj))
 
        (call .sys.ipcinfo_system (subj))
-
-       (call .sys.user.readwrite_subj_semaphores (subj))
+       (call .sys.readwrite_subj_semaphores (subj))
 
        (call .systemd.udev.run.read_file_pattern.type (subj))
 

--- a/src/misc/av/ipcav.cil
+++ b/src/misc/av/ipcav.cil
@@ -138,3 +138,8 @@
     (allow typeattr subj.typeattr (msgq (all)))
     (allow typeattr subj.typeattr (sem (all)))
     (allow typeattr subj.typeattr (shm (all))))
+
+(in sys
+
+    (macro readwrite_subj_semaphores ((type ARG1))
+	   (allow ARG1 subj readwrite_sem)))

--- a/src/misc/av/keyav.cil
+++ b/src/misc/av/keyav.cil
@@ -44,3 +44,14 @@
 (in subj.unconfined
 
     (allow typeattr subj.typeattr (key (all))))
+
+(in sys
+
+    (macro dontaudit_search_subj_keyrings ((type ARG1))
+	   (dontaudit ARG1 subj (key (search))))
+
+    (macro link_subj_keyrings ((type ARG1))
+	   (allow ARG1 subj (key (link))))
+
+    (macro search_subj_keyrings ((type ARG1))
+	   (allow ARG1 subj (key (search)))))

--- a/src/misc/av/socketav.cil
+++ b/src/misc/av/socketav.cil
@@ -1570,3 +1570,11 @@
     (allow typeattr subj.typeattr (unix_dgram_socket (sendto)))
     (allow typeattr subj.typeattr
 	   (unix_stream_socket (accept connectto listen))))
+
+(in sys
+
+    (macro readwrite_subj_netlink_audit_sockets ((type ARG1))
+	   (allow ARG1 subj readwrite_netlink_audit_socket))
+
+    (macro readwrite_subj_netlink_kobject_uevent_sockets ((type ARG1))
+	   (allow ARG1 subj readwrite_netlink_kobject_uevent_socket)))

--- a/src/sys.cil
+++ b/src/sys.cil
@@ -5,9 +5,6 @@
 
 (block sys
 
-       (macro dontaudit_search_subj_keyrings ((type ARG1))
-	      (dontaudit ARG1 subj (key (search))))
-
        (macro dontaudit_setsched_subj_processes ((type ARG1))
 	      (dontaudit ARG1 subj (process (setsched))))
 
@@ -25,21 +22,9 @@
 	      (call .exec.read_file_files (ARG1))
 	      (call .exec.subj_type_transition (ARG1 subj)))
 
-       (macro link_subj_keyrings ((type ARG1))
-	      (allow ARG1 subj (key (link))))
-
-       (macro readwrite_subj_netlink_audit_sockets ((type ARG1))
-	      (allow ARG1 subj readwrite_netlink_audit_socket))
-
-       (macro readwrite_subj_netlink_kobject_uevent_sockets ((type ARG1))
-	      (allow ARG1 subj readwrite_netlink_kobject_uevent_socket))
-
        (macro role_access ((role ARG1)(user ARG2))
 	      (call roleallow.role (ARG1))
 	      (call userrole.user (ARG2)))
-
-       (macro search_subj_keyrings ((type ARG1))
-	      (allow ARG1 subj (key (search))))
 
        (macro shell_exec_subj_type_transition ((type ARG1))
 	      (allow ARG1 subj (process (transition)))

--- a/src/user/sysuser.cil
+++ b/src/user/sysuser.cil
@@ -19,9 +19,6 @@
 	   (macro dyntransition_subj_processes ((type ARG1))
 		  (allow ARG1 subj (process (dyntransition))))
 
-	   (macro readwrite_subj_semaphores ((type ARG1))
-		  (allow ARG1 subj readwrite_sem))
-
 	   (macro role ((role ARG1))
 		  (roleattributeset roleattr ARG1))
 


### PR DESCRIPTION
sys.user does not run devicemapper with a domtrans and sys does

also move some references to optional av's out of sys.cil and into
respective modules
