### PR TITLE
debian container nastyness

### DIFF
--- a/src/agent/misc/systemd/systemdimport.cil
+++ b/src/agent/misc/systemd/systemdimport.cil
@@ -90,10 +90,11 @@
 
     (call .tmp.deletename_file_dirs (subj))
 
+    (call .manage_unlabeled_chr_files (subj))
     (call .manage_unlabeled_dirs (subj))
     (call .manage_unlabeled_files (subj))
     (call .manage_unlabeled_lnk_files (subj))
-
+    (call .relabelfrom_unlabeled_chr_files (subj))
     (call .relabelfrom_unlabeled_dirs (subj))
     (call .relabelfrom_unlabeled_files (subj))
     (call .relabelfrom_unlabeled_lnk_files (subj))

--- a/src/agent/misc/systemd/systemdnspawn.cil
+++ b/src/agent/misc/systemd/systemdnspawn.cil
@@ -48,10 +48,12 @@
 
 (in systemd.import
 
+    (call .systemd.nspawn.container.obj.manage_all_chr_files (subj))
     (call .systemd.nspawn.container.obj.manage_all_dirs (subj))
     (call .systemd.nspawn.container.obj.manage_all_files (subj))
     (call .systemd.nspawn.container.obj.manage_all_lnk_files (subj))
 
+    (call .systemd.nspawn.container.obj.relabelto_all_chr_files (subj))
     (call .systemd.nspawn.container.obj.relabelto_all_dirs (subj))
     (call .systemd.nspawn.container.obj.relabelto_all_files (subj))
     (call .systemd.nspawn.container.obj.relabelto_all_lnk_files (subj)))

--- a/src/misc/av/msgav.cil
+++ b/src/misc/av/msgav.cil
@@ -4,6 +4,8 @@
 (class msg (receive send))
 (classorder (unordered msg))
 
+(defaultrole msg source)
+
 (in invalid.unconfined
 
     (allow typeattr .invalid (msg (all))))


### PR DESCRIPTION
role associated with msg is "object_r" by default...

debootstrap creates a (unlabeled) char node that import wants to import
