### PR TITLE
kernel sysctls

### DIFF
--- a/src/sys/procfile/sysctlfile/kernelsysctlfile/overflowuidkernelsysctlfile.cil
+++ b/src/sys/procfile/sysctlfile/kernelsysctlfile/overflowuidkernelsysctlfile.cil
@@ -3,6 +3,7 @@
 
 (block overflowuid
 
+       (genfscon "proc" "/sys/kernel/overflowgid" sysctlfile_context)
        (genfscon "proc" "/sys/kernel/overflowuid" sysctlfile_context)
 
        (blockinherit .sysctlfile.kernel.template))

--- a/src/sys/procfile/sysctlfile/kernelsysctlfile/randomkernelsysctlfile.cil
+++ b/src/sys/procfile/sysctlfile/kernelsysctlfile/randomkernelsysctlfile.cil
@@ -1,6 +1,10 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
+(in kernel
+
+    (genfscon "proc" "/sys/kernel/randomize_va_space" sysctlfile_context))
+
 (in random
 
     (genfscon "proc" "/sys/kernel/random" sysctlfile_context)


### PR DESCRIPTION
add overflowgid to overflowuid kernel sysctl
exclude randomize_va_space from random kernel sysctl

Signed-off-by: Dominick Grift <dominick.grift@defensec.nl>
