### PR TITLE
remove systemd service enable disable functionality

### DIFF
--- a/src/agent/misc/service.cil
+++ b/src/agent/misc/service.cil
@@ -51,8 +51,7 @@
 
 	      (call .systemd.systemctl.exec.execute_file_files (typeattr))
 
-	      (call .systemd.unit.manage_file_dirs (typeattr))
-	      (call .systemd.unit.manage_file_lnk_files (typeattr)))
+	      (call .systemd.unit.manage_file_dirs (typeattr)))
 
        (block template
 

--- a/src/agent/misc/systemd.cil
+++ b/src/agent/misc/systemd.cil
@@ -1,7 +1,7 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
-(class service (disable enable reload start status stop))
+(class service (reload start status stop))
 (classorder (unordered service))
 
 (block systemd
@@ -1597,12 +1597,6 @@
 		  (macro control_all_services ((type ARG1))
 			 (allow ARG1 typeattr (service (all))))
 
-		  (macro disable_all_services ((type ARG1))
-			 (allow ARG1 typeattr (service (disable))))
-
-		  (macro enable_all_services ((type ARG1))
-			 (allow ARG1 typeattr (service (enable))))
-
 		  (macro reload_all_services ((type ARG1))
 			 (allow ARG1 typeattr (service (reload))))
 
@@ -1629,12 +1623,6 @@
 
 		  (macro control_file_services ((type ARG1))
 			 (allow ARG1 file (service (all))))
-
-		  (macro disable_file_services ((type ARG1))
-			 (allow ARG1 file (service (disable))))
-
-		  (macro enable_file_services ((type ARG1))
-			 (allow ARG1 file (service (enable))))
 
 		  (macro reload_file_services ((type ARG1))
 			 (allow ARG1 file (service (reload))))
@@ -1919,7 +1907,7 @@
 		       (eq t1 exempt.subj.typeattr))
 		   (and (eq r2 .sys.role) (eq t2 .sys.subj))))
 
-    (constrain (service (disable enable reload start status stop))
+    (constrain (service (reload start status stop))
 	       (or (or (or (or (eq r1 r2)
 			       (and (eq r1 exempt.roleattr)
 				    (neq t1 constrained.typeattr)))


### PR DESCRIPTION
highly unlikely that these permissions will ever be re-added

practically this means that confined administrators can not
enable/disable and mask/unmask service units

if you can create file.unit symlinks then you can
enable/disable/mask/unmask any service unit
