### PR TITLE
/var/spool/mail is a symlink to /var/mail

### DIFF
--- a/src/misc.cil
+++ b/src/misc.cil
@@ -517,7 +517,7 @@
 
 	   (call search_file_dirs (typeattr))
 
-	   (call .spool.search_file_pattern.type (typeattr)))
+	   (call .spool.traverse_file_pattern.type (typeattr)))
 
     (block traverse_file_pattern
 


### PR DESCRIPTION
allow traversal
