### PR TITLE
adds a ngroup_max kernel sysctl file so that /bin/id can read it

### DIFF
--- a/src/sys/procfile/sysctlfile/kernelsysctlfile/ngroupsmaxkernelsysctlfile.cil
+++ b/src/sys/procfile/sysctlfile/kernelsysctlfile/ngroupsmaxkernelsysctlfile.cil
@@ -1,0 +1,8 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block ngroupsmax
+
+       (genfscon "proc" "/sys/kernel/ngroups_max" sysctlfile_context)
+
+       (blockinherit .sysctlfile.kernel.template))

--- a/src/user.cil
+++ b/src/user.cil
@@ -109,6 +109,8 @@
 
 	   (call .net.traverse_procfile_pattern.type (typeattr))
 
+	   (call .ngroupsmax.read_sysctlfile_files (typeattr))
+
 	   (call .node.read_sysfile_files (typeattr))
 	   (call .node.search_sysfile_dirs (typeattr))
 


### PR DESCRIPTION
allow unpriv login shells this access
