### PR TITLE
tmp

### DIFF
--- a/src/agent/sysagent/g/grub.cil
+++ b/src/agent/sysagent/g/grub.cil
@@ -5,6 +5,8 @@
 
        (blockinherit .sys.agent.template)
 
+       (allow subj self (capability (sys_admin)))
+
        (call boot.manage_file_dirs (subj))
        (call boot.manage_file_files (subj))
        (call boot.boot_file_type_transition_file (subj))

--- a/src/agent/sysagent/o/osprober.cil
+++ b/src/agent/sysagent/o/osprober.cil
@@ -9,7 +9,7 @@
        (allow subj self (process (setfscreate)))
 
        (call data.execute_file_files (subj))
-       (call data.search_file_dirs (subj))
+       (call data.list_file_dirs (subj))
 
        (call exec.execute_file_files (subj))
 


### PR DESCRIPTION
- /usr/tmp does not exist in debian
- adds osprober
- osprober related
- another osprober data file
- grub osprober
