### PR TITLE
openssh

### DIFF
--- a/src/agent/hybridagent/s/sudo.cil
+++ b/src/agent/hybridagent/s/sudo.cil
@@ -116,10 +116,10 @@
 
     (call .kcore.getattr_procfile_files (subj))
 
-    (call .kernel.read_sysctlfile_files (subj))
-
     (call .locale.data.map_file_pattern.type (subj))
     (call .locale.read_file_pattern.type (subj))
+
+    (call .ngroupsmax.read_sysctlfile_pattern.type (subj))
 
     (call .nss.hosts.type (subj))
     (call .nss.passwdgroup.type (subj))

--- a/src/agent/misc/systemd/systemdtmpfiles.cil
+++ b/src/agent/misc/systemd/systemdtmpfiles.cil
@@ -79,7 +79,7 @@
 
 		  (typeattribute typeattr)
 
-		  (allow typeattr self (process (setfscreate)))
+		  (allow typeattr self (process (setfscreate setrlimit)))
 		  (allow typeattr self create_unix_dgram_socket)
 
 		  (call systemd.logparsenv.type (typeattr))


### PR DESCRIPTION
- adds openssh
- openssh server assume that dyntrans is not used upstream
- adds tcpwrapper conf file and openssh rules
- adds a openssh pty type_change for user
- adds openssh sftp-server
- openssh server pipe usage
- userdbusdaemon specifics
- opensshclient: its optional anyway
- adds sudo
- systemd-tmpfiles sets resource limits
- sudo reads ngroups_max kernel sysctl file
