### PR TITLE
ssh

### DIFF
--- a/src/agent/misc/openssh/opensshserver.cil
+++ b/src/agent/misc/openssh/opensshserver.cil
@@ -157,7 +157,7 @@
 			   (subj))
 		     (call .gnupg.run.deletename_file_dirs (subj))
 
-		     (call .rbacsep.exempt.obj.type (subj)))
+		     (call .rbacsep.exempt.obj.type (.gnupg.agent.run.file)))
 
 	   (optional opensshserver_server_p11kit
 		     (call .p11kit.conf.read_file_pattern.type (subj))


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
