### PR TITLE
ssh

### DIFF
--- a/src/agent/useragent/g/gnupgagent.cil
+++ b/src/agent/useragent/g/gnupgagent.cil
@@ -127,6 +127,27 @@
 
 	   (block run
 
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent" socket
+			   file_context)
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\..*"
+			   socket file_context)
+		  (filecon
+		   "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.browser"
+		   socket file_context)
+		  (filecon
+		   "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.browser\..*"
+		   socket file_context)
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.extra"
+			   socket file_context)
+		  (filecon
+		   "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.extra\..*"
+		   socket file_context)
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.ssh"
+			   socket file_context)
+		  (filecon
+		   "/run/user/%{USERID}/gnupg/d\..*/S\.gpg-agent\.ssh\..*"
+		   socket file_context)
+
 		  (filecon "/run/user/%{USERID}/gnupg/S\.gpg-agent" socket
 			   file_context)
 		  (filecon "/run/user/%{USERID}/gnupg/S\.gpg-agent\..*" socket

--- a/src/agent/useragent/g/gnupgdirmngr.cil
+++ b/src/agent/useragent/g/gnupgdirmngr.cil
@@ -142,6 +142,11 @@
 
 	   (block run
 
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.dirmngr" socket
+			   file_context)
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.dirmngr\..*"
+			   socket file_context)
+
 		  (filecon "/run/user/%{USERID}/gnupg/S\.dirmngr" socket
 			   file_context)
 		  (filecon "/run/user/%{USERID}/gnupg/S\.dirmngr\..*" socket

--- a/src/agent/useragent/g/gnupgscdaemon.cil
+++ b/src/agent/useragent/g/gnupgscdaemon.cil
@@ -110,6 +110,11 @@
 
 	   (block run
 
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.scdaemon" socket
+			   file_context)
+		  (filecon "/run/user/%{USERID}/gnupg/d\..*/S\.scdaemon\..*"
+			   socket file_context)
+
 		  (filecon "/run/user/%{USERID}/gnupg/S\.scdaemon" socket
 			   file_context)
 		  (filecon "/run/user/%{USERID}/gnupg/S\.scdaemon\..*" socket


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
