### PR TITLE
ssh

### DIFF
--- a/src/agent/hybridagent/d/dictionaries.cil
+++ b/src/agent/hybridagent/d/dictionaries.cil
@@ -36,10 +36,15 @@
 	      (filecon "/usr/lib/ispell" dir file_context)
 	      (filecon "/usr/lib/ispell/.*" any file_context)
 
+	      (filecon "/usr/share/dict" dir file_context)
+	      (filecon "/usr/share/dict/.*" any file_context)
+
 	      (filecon "/usr/share/dictionaries-common" dir file_context)
 	      (filecon "/usr/share/dictionaries-common/.*" any file_context)
 
 	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "dict"))
 		     (call .data.file_type_transition
 			   (ARG1 file dir "dictionaries-common")))
 

--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -93,11 +93,7 @@
 
        (call .devpts.search_fs_pattern.type (subj))
 
-       (call .dictionaries.cache.read_file_files (subj))
-       (call .dictionaries.cache.search_file_dirs (subj))
-
-       (call .dictionaries.data.read_file_files (subj))
-       (call .dictionaries.data.search_file_dirs (subj))
+       (call .dictionaries.read_file_pattern.type (subj))
 
        (call .dos.getattr_fs_pattern.type (subj))
        (call .dos.manage_fs_pattern.type (subj))

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -515,6 +515,78 @@
 
 	   (call .dev.search_file_pattern.type (typeattr))))
 
+(in dictionaries
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call cache.read_file_pattern.type (typeattr))
+	   (call conf.read_file_pattern.type (typeattr))
+	   (call data.read_file_pattern.type (typeattr))
+	   (call state.read_file_pattern.type (typeattr))))
+
+(in dictionaries.cache
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+
+	   (call .cache.search_file_pattern.type (typeattr))))
+
+(in dictionaries.conf
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+	   (call read_file_lnk_files (typeattr))
+
+	   (call .conf.search_file_pattern.type (typeattr))))
+
+(in dictionaries.data
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+	   (call read_file_lnk_files (typeattr))
+
+	   (call .data.search_file_pattern.type (typeattr))))
+
+(in dictionaries.state
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+
+	   (call .state.search_file_pattern.type (typeattr))))
+
 (in dos
 
     (block getattr_fs_pattern
@@ -582,7 +654,10 @@
 
 	   (typeattribute typeattr)
 
-	   (call data.read_file_pattern.type (typeattr))))
+	   (call conf.read_file_pattern.type (typeattr))
+	   (call data.read_file_pattern.type (typeattr))
+	   (call home.read_file_pattern.type (typeattr))
+	   (call run.read_file_pattern.type (typeattr))))
 
 (in environ.conf
 
@@ -640,14 +715,6 @@
 	   (call read_file_files (typeattr))
 
 	   (call .user.home.conf.search_file_pattern.type (typeattr))))
-
-(in environ.read_file_pattern
-
-    (call conf.read_file_pattern.type (typeattr))
-
-    (call home.read_file_pattern.type (typeattr))
-
-    (call run.read_file_pattern.type (typeattr)))
 
 (in environ.run
 

--- a/src/user.cil
+++ b/src/user.cil
@@ -77,7 +77,12 @@
 
 	   (call .devpts.search_fs_pattern.type (typeattr))
 
+	   (call .dictionaries.read_file_pattern.type (typeattr))
+
 	   (call .editor.conf.read_file_files (typeattr))
+	   (call .editor.data.list_file_dirs (typeattr))
+	   (call .editor.data.read_file_files (typeattr))
+	   (call .editor.data.read_file_lnk_files (typeattr))
 
 	   (call .exec.entrypoint_file_files (typeattr))
 	   (call .exec.execute_file_files (typeattr))


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
- reading dictionaries
