### PR TITLE
ssh

### DIFF
--- a/src/agent/hybridagent/s/sudo.cil
+++ b/src/agent/hybridagent/s/sudo.cil
@@ -375,7 +375,7 @@
 
 	   (call .crypto.read_sysctlfile_pattern.type (subj))
 
-	   (call .editor.conf.read_file_files (subj))
+	   (call .editor.read_file_pattern.type (subj))
 
 	   (call .exec.execute_file_files (subj))
 

--- a/src/agent/misc/systemd/systemdsystemctl.cil
+++ b/src/agent/misc/systemd/systemdsystemctl.cil
@@ -59,7 +59,7 @@
 
 	   (call .dbus.client.type (subj))
 
-	   (call .editor.conf.read_file_files (subj))
+	   (call .editor.read_file_pattern.type (subj))
 
 	   (call .file.unit.control_all_services (subj))
 	   (call .file.unit.manage_all_files (subj))

--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -91,6 +91,7 @@
        (call .devices.read_sysfile_files (subj))
        (call .devices.search_sysfile_pattern.type (subj))
 
+       (call .devpts.getattr_fs (subj))
        (call .devpts.search_fs_pattern.type (subj))
 
        (call .dictionaries.read_file_pattern.type (subj))

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -632,6 +632,62 @@
 
 	   (call .dev.search_file_pattern.type (typeattr))))
 
+(in editor
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call conf.read_file_pattern.type (typeattr))
+	   (call data.read_file_pattern.type (typeattr))
+	   (call state.read_file_pattern.type (typeattr))))
+
+(in editor.conf
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+
+	   (call .conf.search_file_pattern.type (typeattr))))
+
+(in editor.data
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+	   (call read_file_lnk_files (typeattr))
+
+	   (call .data.search_file_pattern.type (typeattr))))
+
+(in editor.state
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+
+	   (call .state.search_file_pattern.type (typeattr))))
+
 (in efivar
 
     (block search_fs_pattern

--- a/src/user.cil
+++ b/src/user.cil
@@ -79,10 +79,7 @@
 
 	   (call .dictionaries.read_file_pattern.type (typeattr))
 
-	   (call .editor.conf.read_file_files (typeattr))
-	   (call .editor.data.list_file_dirs (typeattr))
-	   (call .editor.data.read_file_files (typeattr))
-	   (call .editor.data.read_file_lnk_files (typeattr))
+	   (call .editor.read_file_pattern.type (typeattr))
 
 	   (call .exec.entrypoint_file_files (typeattr))
 	   (call .exec.execute_file_files (typeattr))


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
- reading dictionaries
- reading editor files
