### PR TITLE
ssh

### DIFF
--- a/src/agent/hybridagent/d/dictionaries.cil
+++ b/src/agent/hybridagent/d/dictionaries.cil
@@ -42,11 +42,16 @@
 	      (filecon "/usr/share/dictionaries-common" dir file_context)
 	      (filecon "/usr/share/dictionaries-common/.*" any file_context)
 
+	      (filecon "/usr/share/ispell" dir file_context)
+	      (filecon "/usr/share/ispell/.*" any file_context)
+
 	      (macro data_file_type_transition_file ((type ARG1))
 		     (call .data.file_type_transition
 			   (ARG1 file dir "dict"))
 		     (call .data.file_type_transition
-			   (ARG1 file dir "dictionaries-common")))
+			   (ARG1 file dir "dictionaries-common"))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "ispell")))
 
 	      (macro lib_file_type_transition_file ((type ARG1))
 		     (call .lib.file_type_transition


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
- reading dictionaries
- reading editor files
- dictionaries everywhere
