### PR TITLE
ssh

### DIFF
--- a/src/agent/misc/systemd/usersystemd.cil
+++ b/src/agent/misc/systemd/usersystemd.cil
@@ -397,6 +397,8 @@
 	   (call .systemd.logparsenv.type (subj))
 	   (call .systemd.notify.type (subj))
 
+	   (call .systemd.data.search_file_dirs (subj))
+
 	   (call .systemd.exec.entrypoint_file_files (subj))
 	   (call .systemd.exec.execute_file_files (subj))
 

--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -119,6 +119,9 @@
 
        (call .imap.imaps.nameconnect_port_tcp_sockets (subj))
 
+       (call .info.data.read_file_files (subj))
+       (call .info.data.search_file_dirs (subj))
+
        (call .irc.nameconnect_port_tcp_sockets (subj))
 
        (call .lib.home.manage_file_dirs (subj))

--- a/src/file/datafile/infodatafile.cil
+++ b/src/file/datafile/infodatafile.cil
@@ -1,0 +1,21 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block info
+
+       (block data
+
+	      (filecon "/usr/share/info" dir file_context)
+	      (filecon "/usr/share/info/.*" any file_context)
+
+	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "info")))
+
+	      (blockinherit .file.data.base_template)
+	      (blockinherit .file.macro_template_dirs)
+	      (blockinherit .file.macro_template_files)))
+
+(in file.unconfined
+
+    (call .info.data.data_file_type_transition_file (typeattr)))


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
- reading dictionaries
- reading editor files
- dictionaries everywhere
- adds info data file for emacs and allow usersystemd to traverse
