### PR TITLE
ssh

### DIFF
--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -565,7 +565,9 @@
     (call .emacs.tmp.relabel_file_dirs (subj))
     (call .emacs.tmp.relabel_file_files (subj))
     (call .emacs.tmp.relabel_file_lnk_files (subj))
-    (call .emacs.tmp.relabel_file_sock_files (subj)))
+    (call .emacs.tmp.relabel_file_sock_files (subj))
+
+    (call .info.data.readinherited_file_files (subj)))
 
 (in wheel
 


### PR DESCRIPTION
- openssh (gnupg) agent forwarding
- adds git client, emacs and daemon
- adds alsa data because gets pulled in by emacs-nox
- adds emacs
- adds dictionaries
- emacs and dictionaries
- make tmp.file tmp.fs and mqueue.fs rbacsep exempt
- opensshserver: fix making gnupg-agent.run.file rbacsep exempt
- adds editor data and state files
- gnupg: fix specs for sock file contexts
- reading dictionaries
- reading editor files
- dictionaries everywhere
- adds info data file for emacs and allow usersystemd to traverse
- user.subj reads inherited info data files via emacs
