### PR TITLE
stuff

### DIFF
--- a/src/agent/hybridagent/p/passwd.cil
+++ b/src/agent/hybridagent/p/passwd.cil
@@ -5,6 +5,7 @@
 
     (blockinherit .hybrid.agent.template)
 
+    (allow subj self (capability (setuid)))
     (allow subj self (process (setrlimit)))
     (allow subj self create_unix_dgram_socket)
 


### PR DESCRIPTION
- chage and passwd
- chage doesnt use unixupdate and passwd is hybrid
- chage creates netlink selinux socket
- adds chpasswd and strips passwd from unneeded perms
- passwd setuid is still needed
