### PR TITLE
stuff

### DIFF
--- a/src/agent/hybridagent/p/passwd.cil
+++ b/src/agent/hybridagent/p/passwd.cil
@@ -20,8 +20,6 @@
     (call .locale.data.map_file_pattern.type (subj))
     (call .locale.read_file_pattern.type (subj))
 
-    (call .logindefs.read_file_files (subj))
-
     (call .nss.passwdgroup.type (subj))
 
     (call .pam.linked.type (subj))
@@ -29,11 +27,6 @@
     (call .proc.getattr_fs_pattern.type (subj))
 
     (call .random.read_nodedev_chr_files (subj))
-
-    (call .selinux.file.read_file_pattern.type (subj))
-    (call .selinux.map_fs_files (subj))
-
-    (call .state.search_file_pattern.type (subj))
 
     (call .systemd.journal.relay_msgs.type (subj))
 

--- a/src/agent/misc/shadowutils/chpasswd.cil
+++ b/src/agent/misc/shadowutils/chpasswd.cil
@@ -17,25 +17,15 @@
        (call .locale.data.map_file_pattern.type (subj))
        (call .locale.read_file_pattern.type (subj))
 
-       (call .logindefs.read_file_files (subj))
-
        (call .nss.passwdgroup.type (subj))
 
-       (call .pam.conf.read_file_files (subj))
-       (call .pam.conf.search_file_dirs (subj))
+       (call .pam.linked.type (subj))
 
        (call .proc.getattr_fs_pattern.type (subj))
 
        (call .rbacsep.constrained.type (subj))
-       (call .rbacsep.usefdsource.type (subj))
-
-       (call .selinux.linked.type (subj))
-
-       (call .shadow.dontaudit_read_file_files (subj))
 
        (call .systemd.journal.relay_msgs.type (subj))
-
-       (call .unixchkpwd.subj_type_transition (subj))
 
        (call .unixupdate.subj_type_transition (subj))
 


### PR DESCRIPTION
- chage and passwd
- chage doesnt use unixupdate and passwd is hybrid
- chage creates netlink selinux socket
- adds chpasswd and strips passwd from unneeded perms
- passwd setuid is still needed
- chpasswd: looks very different now ...
- passwd/chpasswd are pam linked
