### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/openssh/opensshserver.cil
+++ b/src/agent/misc/openssh/opensshserver.cil
@@ -100,6 +100,8 @@
 
 	   (call .pam.login.type (subj))
 
+	   (call .passwd.subj_type_transition (subj))
+
 	   (call .proc.getattr_fs_pattern.type (subj))
 
 	   (call .ptmx.readwrite_nodedev_chr_files (subj))

--- a/src/agent/misc/pam/unixchkpwd.cil
+++ b/src/agent/misc/pam/unixchkpwd.cil
@@ -29,6 +29,8 @@
 
        (call .systemd.journal.relay_msgs.type (subj))
 
+       (call .user.termdev.dontaudit_readwriteinherited_all_chr_files (subj))
+
        (block exec
 
 	      (filecon "/usr/bin/unix_chkpwd" file file_context)))

--- a/src/dev/termdev/usertermdev.cil
+++ b/src/dev/termdev/usertermdev.cil
@@ -27,6 +27,9 @@
 		  (allow ARG1 typeattr appendinherited_chr_file)
 		  (allowx ARG1 typeattr (ioctl chr_file (not (0x5412)))))
 
+	   (macro dontaudit_readwriteinherited_all_chr_files ((type ARG1))
+		  (dontaudit ARG1 typeattr readwriteinherited_chr_file))
+
 	   (macro open_all_chr_files ((type ARG1))
 		  (allow ARG1 typeattr (chr_file (open))))
 


### PR DESCRIPTION
- chage and passwd
- chage doesnt use unixupdate and passwd is hybrid
- chage creates netlink selinux socket
- adds chpasswd and strips passwd from unneeded perms
- passwd setuid is still needed
- chpasswd: looks very different now ...
- passwd/chpasswd are pam linked
- adds vipw
- unixchkpwd: for when openssh-server runs passwd (forced)
