### PR TITLE
modular

### DIFF
--- a/src/agent/hybridagent/p/passwd.cil
+++ b/src/agent/hybridagent/p/passwd.cil
@@ -30,7 +30,6 @@
 
     (call .systemd.journal.relay_msgs.type (subj))
 
-    (call .unixupdate.role (roleattr))
     (call .unixupdate.subj_type_transition (subj))
 
     (block exec

--- a/src/agent/misc/openssh/opensshclient.cil
+++ b/src/agent/misc/openssh/opensshclient.cil
@@ -108,16 +108,18 @@
 
 	   (call .tmp.deletename_file_dirs (subj))
 
-	   (call .user.shell_exec_subj_type_transition (subj))
-
 	   (call .user.run.deletename_file_dirs (subj))
-
-	   (call .user.systemd.agent (subj exec.file))
 
 	   (optional opensshclient_agent_p11kit
 		     (call .p11kit.conf.read_file_pattern.type (subj))
 		     (call .p11kit.data.map_file_files (subj))
 		     (call .p11kit.data.read_file_pattern.type (subj)))
+
+	   (optional opensshclient_agent_user
+		     (call .user.shell_exec_subj_type_transition (subj)))
+
+	   (optional opensshclient_agent_usersystemd
+		     (call .user.systemd.agent (subj exec.file)))
 
 	   (block exec
 
@@ -220,8 +222,6 @@
 
 	   (call .media.search_file_pattern.type (subj))
 
-	   (call .media.home.traverse_file_pattern.type (subj))
-
 	   (call .mount.dontaudit_link_subj_keyrings (subj))
 
 	   (call .net.nodebind_netnode_tcp_sockets (subj))
@@ -251,10 +251,11 @@
 
 	   (call .user.run.search_file_pattern.type (subj))
 
-	   (call .user.shell_exec_subj_type_transition (subj))
-
 	   (optional opensshclient_client_gnupgagent
 		     (call .gnupg.agent.unix_stream_connect (subj)))
+
+	   (optional opensshlclient_client_mediahomefile
+		     (call .media.home.traverse_file_pattern.type (subj)))
 
 	   (optional opensshclient_client_opensshserver
 		     (call server.unix_stream_connect (subj)))
@@ -263,6 +264,9 @@
 		     (call .p11kit.conf.read_file_pattern.type (subj))
 		     (call .p11kit.data.map_file_files (subj))
 		     (call .p11kit.data.read_file_pattern.type (subj)))
+
+	   (optional opensshclient_client_user
+		     (call .user.shell_exec_subj_type_transition (subj)))
 
 	   (block conf
 
@@ -368,35 +372,3 @@
 
 		  (filecon "/usr/bin/ssh-keysign" file
 			   file_context))))
-
-(in user
-
-    (call .openssh.add.role (role))
-    (call .openssh.add.tmp.manage_file_files (subj))
-    (call .openssh.add.tmp.relabel_file_files (subj))
-    (call .openssh.agent.role (role))
-    (call .openssh.agent.run.manage_file_sock_files (subj))
-    (call .openssh.agent.run.relabel_file_sock_files (subj))
-    (call .openssh.agent.run.user_run_file_type_transition_file (subj))
-    (call .openssh.agent.tmp.manage_file_dirs (subj))
-    (call .openssh.agent.tmp.manage_file_sock_files (subj))
-    (call .openssh.agent.tmp.relabel_file_dirs (subj))
-    (call .openssh.agent.tmp.relabel_file_sock_files (subj))
-    (call .openssh.client.role (role))
-    (call .openssh.client.tmp.manage_file_sock_files (subj))
-    (call .openssh.client.tmp.relabel_file_sock_files (subj))
-    (call .openssh.home.manage_file_dirs (subj))
-    (call .openssh.home.manage_file_files (subj))
-    (call .openssh.home.relabel_file_dirs (subj))
-    (call .openssh.home.relabel_file_files (subj))
-    (call .openssh.home.user_home_file_type_transition_file (subj))
-    (call .openssh.keygen.role (role))
-    (call .openssh.keysign.role (role)))
-
-(in wheel
-
-    (call .openssh.add.role (role))
-    (call .openssh.agent.role (role))
-    (call .openssh.client.role (role))
-    (call .openssh.keygen.role (role))
-    (call .openssh.keysign.role (role)))

--- a/src/agent/misc/openssh/opensshserver.cil
+++ b/src/agent/misc/openssh/opensshserver.cil
@@ -140,17 +140,6 @@
 
 	   (call .tmp.deletename_file_dirs (subj))
 
-	   (call .user.readwrite_ptytermdev_chr_files (subj))
-	   (call .user.relabelto_ptytermdev_chr_files (subj))
-	   (call .user.setattr_ptytermdev_chr_files (subj))
-
-	   (call .user.unpriv.create_all_keyrings (subj))
-	   (call .user.unpriv.rlimitinh_all_processes (subj))
-	   (call .user.unpriv.signal_all_processes (subj))
-	   (call .user.unpriv.signull_all_processes (subj))
-	   (call .user.unpriv.transition_all_processes (subj))
-	   (call .user.unpriv.write_all_keyrings (subj))
-
 	   (call .user.run.search_file_pattern.type (subj))
 
 	   (optional opensshserver_server_gnupgagent
@@ -165,6 +154,19 @@
 		     (call .p11kit.conf.read_file_pattern.type (subj))
 		     (call .p11kit.data.map_file_files (subj))
 		     (call .p11kit.data.read_file_pattern.type (subj)))
+
+	   (optional opensshserver_server_unprivuser
+		     (call .user.unpriv.create_all_keyrings (subj))
+		     (call .user.unpriv.rlimitinh_all_processes (subj))
+		     (call .user.unpriv.signal_all_processes (subj))
+		     (call .user.unpriv.signull_all_processes (subj))
+		     (call .user.unpriv.transition_all_processes (subj))
+		     (call .user.unpriv.write_all_keyrings (subj)))
+
+	   (optional opensshserver_server_userptytermdev
+		     (call .user.readwrite_ptytermdev_chr_files (subj))
+		     (call .user.relabelto_ptytermdev_chr_files (subj))
+		     (call .user.setattr_ptytermdev_chr_files (subj)))
 
 	   (block conf
 
@@ -269,14 +271,6 @@
 
 (in user.agent
 
-    (call .openssh.server.readwriteinherited_subj_fifo_files (typeattr))
-    (call .openssh.server.use_subj_fds (typeattr))
-
-    (call .rbacsep.exemptsource.type (typeattr)))
-
-(in user.unpriv
-
-    (call .openssh.server.ptytermdev_type_change (typeattr ptytermdev))
     (call .openssh.server.readwriteinherited_subj_fifo_files (typeattr))
     (call .openssh.server.use_subj_fds (typeattr))
 

--- a/src/agent/misc/openssh/opensshsftpserver.cil
+++ b/src/agent/misc/openssh/opensshsftpserver.cil
@@ -26,8 +26,6 @@
 
 	   (call .media.search_file_dirs (subj))
 
-	   (call .media.home.traverse_file_pattern.type (subj))
-
 	   (call .nfs.getattr_fs_pattern.type (subj))
 	   (call .nfs.manage_fs_pattern.type (subj))
 
@@ -41,6 +39,9 @@
 	   (call .user.home.manage_file_files (subj))
 
 	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional opensshsftpserver_mediahomefile
+		     (call .media.home.traverse_file_pattern.type (subj)))
 
 	   (optional opensshsftpserver_p11kit
 		     (call .p11kit.conf.read_file_pattern.type (subj))
@@ -60,11 +61,3 @@
 (in openssh.server
 
     (call openssh.sftpserver.exec.getattr_file_files (subj)))
-
-(in user
-
-    (call .openssh.sftpserver.role (role)))
-
-(in wheel
-
-    (call .openssh.sftpserver.role (role)))

--- a/src/agent/misc/service.cil
+++ b/src/agent/misc/service.cil
@@ -1,0 +1,133 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block service
+
+       (block admin
+
+	      (macro role ((role ARG1))
+		     (roleattributeset roleattr ARG1))
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (roleattribute roleattr)
+	      (typeattribute typeattr)
+
+	      (call .cache.traverse_file_pattern.type (typeattr))
+
+	      (call .ibac.objchangesys.type (typeattr))
+
+	      (call .log.traverse_file_pattern.type (typeattr))
+
+	      (call .random.read_sysctlfile_pattern.type (typeattr))
+
+	      (call .rbac.objchangesys.type (typeattr))
+
+	      (call .selinux.file.read_file_pattern.type (typeattr))
+	      (call .selinux.mapread_fs_pattern.type (typeattr))
+
+	      (call .state.traverse_file_pattern.type (typeattr))
+
+	      (call .sys.reload_system (typeattr))
+	      (call .sys.status_system (typeattr))
+
+	      (call .systemd.pager.type (typeattr))
+	      (call .systemd.private.type (typeattr))
+
+	      (call .systemd.askpassword.client.type (typeattr))
+	      (call .systemd.askpassword.role (roleattr))
+	      (call .systemd.askpassword.ttyagent.role (roleattr))
+
+	      (call .systemd.conf.traverse_file_pattern.type (typeattr))
+
+	      (call .systemd.journal.log.map_file_pattern.type (typeattr))
+	      (call .systemd.journal.log.read_file_pattern.type (typeattr))
+
+	      (call .systemd.systemctl.exec.execute_file_files (typeattr))
+
+	      (call .systemd.unit.manage_file_dirs (typeattr))
+
+	      (optional service_polkit
+			(call .polkit.ttyagent.role (roleattr))
+			(call .polkit.ttyagent.subj_type_transition
+			      (typeattr))))
+
+       (block template
+
+	      (blockabstract template)
+
+	      (block service
+
+		     (block admin
+
+			    (macro role ((role ARG1))
+				   (roleattributeset roleattr ARG1))
+
+			    (macro type ((type ARG1))
+				   (typeattributeset typeattr ARG1))
+
+			    (roleattribute roleattr)
+			    (typeattribute typeattr)
+
+			    (allow typeattr self
+				   (capability (chown dac_override
+						      dac_read_search fowner
+						      fsetid kill sys_ptrace
+						      sys_resource)))
+			    (allow typeattr self (cap_userns (kill sys_ptrace)))
+			    (allow typeattr self (process (setfscreate)))
+
+			    (allow typeattr obj.typeattr manage_dir)
+			    (allow typeattr obj.typeattr manage_fifo_file)
+			    (allow typeattr obj.typeattr manage_file)
+			    (allow typeattr obj.typeattr manage_lnk_file)
+			    (allow typeattr obj.typeattr manage_sock_file)
+			    (allow typeattr obj.typeattr (file (map)))
+
+			    (allow typeattr obj.typeattr relabel_dir)
+			    (allow typeattr obj.typeattr relabel_fifo_file)
+			    (allow typeattr obj.typeattr relabel_file)
+			    (allow typeattr obj.typeattr relabel_lnk_file)
+			    (allow typeattr obj.typeattr relabel_sock_file)
+
+			    (allow typeattr subj.typeattr
+				   (process (getattr getcap getrlimit getsched
+						     ptrace setrlimit setsched
+						     signal signull sigkill
+						     sigstop)))
+
+			    (allow typeattr subj.typeattr list_dir)
+			    (allow typeattr subj.typeattr read_file)
+			    (allow typeattr subj.typeattr read_lnk_file)
+
+			    (allow typeattr unit.typeattr manage_file)
+			    (allow typeattr unit.typeattr relabel_file)
+			    (allow typeattr unit.typeattr (file (map)))
+			    (allow typeattr unit.typeattr (service (all)))
+
+			    (call .service.admin.role (roleattr))
+			    (call .service.admin.type (typeattr)))
+
+		     (block obj
+
+			    (macro type ((type ARG1))
+				   (typeattributeset typeattr ARG1))
+
+			    (typeattribute typeattr))
+
+		     (block subj
+
+			    (macro type ((type ARG1))
+				   (typeattributeset typeattr ARG1))
+
+			    (typeattribute typeattr)
+
+			    (allow typeattr admin.typeattr (process (sigchld))))
+
+		     (block unit
+
+			    (macro type ((type ARG1))
+				   (typeattributeset typeattr ARG1))
+
+			    (typeattribute typeattr)))))

--- a/src/agent/misc/systemd/systemdacpower.cil
+++ b/src/agent/misc/systemd/systemdacpower.cil
@@ -1,0 +1,16 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block acpower
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-ac-power" file
+			   file_context))))

--- a/src/agent/misc/systemd/systemdbacklight.cil
+++ b/src/agent/misc/systemd/systemdbacklight.cil
@@ -1,0 +1,55 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.backlight
+
+    (blockinherit .sys.agent.template)
+
+    (allow subj self create_unix_dgram_socket)
+
+    (call state.manage_file_files (subj))
+    (call state.readwrite_file_dirs (subj))
+
+    (call systemd.logparsenv.type (subj))
+
+    (call systemd.state.search_file_pattern.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call systemd.udev.run.read_file_pattern.type (subj))
+
+    (call .bus.list_sysfile_dirs (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .class.list_sysfile_dirs (subj))
+    (call .class.read_sysfile_lnk_files (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .devices.readwrite_sysfile_files (subj))
+    (call .devices.traverse_sysfile_pattern.type (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (call .xattr.getattr_fs_pattern.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-backlight" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-backlight.*@\.service.*"
+		    file file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdbinfmt.cil
+++ b/src/agent/misc/systemd/systemdbinfmt.cil
@@ -1,0 +1,74 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .systemd.binfmt.conf.conf_file_type_transition_file (typeattr))
+    (call .systemd.binfmt.data.lib_file_type_transition_file (typeattr))
+    (call .systemd.binfmt.run.run_file_type_transition_file (typeattr)))
+
+(in systemd
+
+    (block binfmt
+
+	   (blockinherit .sys.agent.template)
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call data.list_file_dirs (subj))
+	   (call data.read_file_files (subj))
+
+	   (call run.list_file_dirs (subj))
+	   (call run.read_file_files (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block conf
+
+		  (filecon "/etc/binfmt\.d" dir file_context)
+		  (filecon "/etc/binfmt\.d/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "binfmt.d")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block data
+
+		  (filecon "/usr/lib/binfmt\.d" dir file_context)
+		  (filecon "/usr/lib/binfmt\.d/.*" any file_context)
+
+		  (macro lib_file_type_transition_file ((type ARG1))
+			 (call .lib.file_type_transition
+			       (ARG1 file dir "binfmt.d")))
+
+		  (blockinherit .file.data.base_template)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-binfmt" file file_context))
+
+	   (block run
+
+		  (filecon "/run/binfmt\.d" dir file_context)
+		  (filecon "/run/binfmt\.d/.*" any file_context)
+
+		  (macro run_file_type_transition_file ((type ARG1))
+			 (call .run.file_type_transition
+			       (ARG1 file dir "binfmt.d")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.run.base_template))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/system/systemd-binfmt\.service.*"
+			   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdblessboot.cil
+++ b/src/agent/misc/systemd/systemdblessboot.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block blessboot
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-bless-boot" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-bless-boot\.service.*" file
+		   file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdbootchknofail.cil
+++ b/src/agent/misc/systemd/systemdbootchknofail.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block bootchknofail
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-boot-check-no-failures"
+			   file file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-boot-check-no-failures\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdcgroupsagent.cil
+++ b/src/agent/misc/systemd/systemdcgroupsagent.cil
@@ -1,0 +1,14 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.cgroupsagent
+
+    (blockinherit .sys.agent.template)
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-cgroups-agent" file
+		    file_context)))

--- a/src/agent/misc/systemd/systemdcryptsetup.cil
+++ b/src/agent/misc/systemd/systemdcryptsetup.cil
@@ -1,0 +1,64 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block cryptsetup
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (process (getsched)))
+	   (allow subj self (capability (sys_admin)))
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .cpu.read_sysfile_files (subj))
+	   (call .cpu.search_sysfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devicemapper.cryptsetup.run.manage_file_dirs (subj))
+	   (call .devicemapper.cryptsetup.run.manage_file_files (subj))
+	   (call .devicemapper.cryptsetup.run.run_file_type_transition_file
+		 (subj))
+
+	   (call .devices.read_procfile_files (subj))
+
+	   (call .devtmp.getattr_fs (subj))
+
+	   (call .dmcontrol.readwrite_nodedev_chr_files (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_nodedev_chr_files (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .stordev.read.type (subj))
+	   (call .stordev.read_all_blk_files (subj))
+	   (call .stordev.read_all_chr_files (subj))
+
+	   (call .sys.ipcinfo_subj_system (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-cryptsetup" file
+			   file_context))))

--- a/src/agent/misc/systemd/systemdfsck.cil
+++ b/src/agent/misc/systemd/systemdfsck.cil
@@ -54,6 +54,9 @@
     (allow subj self create_unix_dgram_socket)
     (allow subj self create_unix_stream_socket)
 
+    (call run.manage_file_files (subj))
+    (call run.systemd_run_file_type_transition_file (subj))
+
     (call systemd.fsckd.unix_stream_connect (subj))
 
     (call systemd.logparsenv.type (subj))
@@ -64,9 +67,6 @@
 ;;    (call systemd.quotacheck.run.systemd_run_file_type_transition_file (subj))
 
     (call systemd.udev.run.read_file_pattern.type (subj))
-
-    (call run.manage_file_files (subj))
-    (call run.systemd_run_file_type_transition_file (subj))
 
     (call .caplastcap.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/misc/systemd/systemdfsck.cil
+++ b/src/agent/misc/systemd/systemdfsck.cil
@@ -63,9 +63,6 @@
 
     (call systemd.journal.relay_msgs.type (subj))
 
-;;    (call systemd.quotacheck.run.manage_file_files (subj))
-;;    (call systemd.quotacheck.run.systemd_run_file_type_transition_file (subj))
-
     (call systemd.udev.run.read_file_pattern.type (subj))
 
     (call .caplastcap.read_sysctlfile_pattern.type (subj))
@@ -96,6 +93,11 @@
     (call .stordev.getattr_all_chr_files (subj))
 
     (call .xattr.getattr_fs_pattern.type (subj))
+
+    (optional systemdfsck_systemdquotacheck
+	      (call systemd.quotacheck.run.manage_file_files (subj))
+	      (call systemd.quotacheck.run.systemd_run_file_type_transition_file
+		    (subj)))
 
     (block exec
 

--- a/src/agent/misc/systemd/systemdhibernateresume.cil
+++ b/src/agent/misc/systemd/systemdhibernateresume.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block hibernateresume
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-hibernate-resume" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-hibernate-resume@.*\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdhwdb.cil
+++ b/src/agent/misc/systemd/systemdhwdb.cil
@@ -1,0 +1,53 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block hwdb
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_netlink_selinux_socket)
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.conf.search_file_pattern.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.udev.conf.conf_file_type_transition_file (subj))
+	   (call systemd.udev.conf.manage_file_dirs (subj))
+	   (call systemd.udev.conf.manage_file_files (subj))
+	   (call systemd.udev.conf.map_file_files (subj))
+	   (call systemd.udev.conf.relabel_file_files (subj))
+	   (call systemd.udev.data.lib_file_type_transition_file (subj))
+	   (call systemd.udev.data.manage_file_dirs (subj))
+	   (call systemd.udev.data.manage_file_files (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .ibac.objchangesys.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbac.objchangesys.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-hwdb" file file_context))))

--- a/src/agent/misc/systemd/systemdhwdb.cil
+++ b/src/agent/misc/systemd/systemdhwdb.cil
@@ -8,7 +8,6 @@
 	   (blockinherit .sys.agent.template)
 
 	   (allow subj self (process (setfscreate)))
-	   (allow subj self create_netlink_selinux_socket)
 	   (allow subj self create_unix_dgram_socket)
 
 	   (call systemd.logparsenv.type (subj))

--- a/src/agent/misc/systemd/systemdinitctl.cil
+++ b/src/agent/misc/systemd/systemdinitctl.cil
@@ -1,0 +1,27 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block initctl
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-initctl" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-bless-initctl\.service.*"
+		   file file_context)
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-bless-initctl\.socket.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdlocale.cil
+++ b/src/agent/misc/systemd/systemdlocale.cil
@@ -1,0 +1,79 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block locale
+
+	   (blockinherit .dbus.nameclient.template)
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.notify.type (subj))
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .conf.deletename_file_dirs (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .locale.conf.manage_file_files (subj))
+	   (call .locale.conf.conf_file_type_transition_file (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_nodedev_chr_files (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .sys.reload_system (subj))
+	   (call .sys.start_system (subj))
+
+	   (call .x11.conf.conf_file_type_transition_file (subj))
+	   (call .x11.conf.manage_file_dirs (subj))
+	   (call .x11.conf.manage_file_files (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdlocale_polkit
+		     (call .polkit.sendmsg_subj_dbus.type (subj)))
+
+	   (optional systemdlocale_systemvconsolesetup
+		     (call .systemd.vconsolesetup.conf.conf_file_type_transition_file
+			   (subj))
+		     (call .systemd.vconsolesetup.conf.manage_file_files (subj))
+		     (call .systemd.vconsolesetup.unit.start_file_services
+			   (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-localed" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/system/systemd-localed\.service.*"
+			   file file_context)
+
+		  (blockinherit .file.unit.template)
+
+		  (call .dbus.activated.unit.type (file)))))

--- a/src/agent/misc/systemd/systemdlocale.cil
+++ b/src/agent/misc/systemd/systemdlocale.cil
@@ -57,13 +57,6 @@
 	   (optional systemdlocale_polkit
 		     (call .polkit.sendmsg_subj_dbus.type (subj)))
 
-	   (optional systemdlocale_systemvconsolesetup
-		     (call .systemd.vconsolesetup.conf.conf_file_type_transition_file
-			   (subj))
-		     (call .systemd.vconsolesetup.conf.manage_file_files (subj))
-		     (call .systemd.vconsolesetup.unit.start_file_services
-			   (subj)))
-
 	   (block exec
 
 		  (filecon "/usr/lib/systemd/systemd-localed" file

--- a/src/agent/misc/systemd/systemdmachineidsetup.cil
+++ b/src/agent/misc/systemd/systemdmachineidsetup.cil
@@ -1,0 +1,120 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block machineidsetup
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self
+		  (capability (dac_override dac_read_search setgid setuid
+					    sys_admin sys_chroot)))
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_netlink_kobject_uevent_socket)
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call tmp.manage_file_dirs (subj))
+	   (call tmp.mounton_file_dirs (subj))
+	   (call tmp.tmp_file_type_transition_file (subj))
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .bus.search_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .conf.deletename_file_dirs (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .debug.search_fs_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_pattern.type (subj))
+
+	   (call .fsck.subj_type_transition (subj))
+
+	   (call .ibac.objchangesys.type (subj))
+
+	   (call .kernel.read_sysfile_files (subj))
+	   (call .kernel.search_sysfile_pattern.type (subj))
+
+	   (call .loop.readwrite_stordev_blk_files (subj))
+
+	   (call .loopcontrol.readwrite_nodedev_chr_files (subj))
+
+	   (call .machineid.conf_file_type_transition_file (subj))
+	   (call .machineid.manage_file_files (subj))
+
+	   (call .mount.image.readwrite_all_files (subj))
+	   (call .mount.image.search_all_dirs (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbac.objchangesys.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .root.mounton_file_dirs (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .state.search_file_pattern.type (subj))
+
+	   (call .stordev.readwrite.type (subj))
+
+	   (call .sys.dontaudit_setsched_subj_processes (subj))
+
+	   (call .tmp.deletename_file_dirs (subj))
+	   (call .tmp.getattr_fs_pattern.type (subj))
+
+	   (call .xattr.mount_fs (subj))
+	   (call .xattr.unmount_fs (subj))
+
+	   (optional systemdmachineidsetup_systemdnspawn
+		     (call .systemd.nspawn.container.obj.manage_all_dirs
+			   (subj))
+		     (call .systemd.nspawn.container.obj.manage_all_files
+			   (subj))
+		     (call .systemd.nspawn.container.obj.manage_all_lnk_files
+			   (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-machine-id-setup" file
+			   file_context))
+
+	   (block tmp
+
+		  (macro tmp_file_type_transition_file ((type ARG1))
+			 (call .tmp.file_type_transition
+			       (ARG1 file dir "*")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.tmp.base_template))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-machine-id-commit\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdmakefs.cil
+++ b/src/agent/misc/systemd/systemdmakefs.cil
@@ -1,0 +1,45 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block makefs
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (capability (sys_resource)))
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call .block.traverse_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devices.list_sysfile_pattern.type (subj))
+	   (call .devices.read_sysfile_files (subj))
+
+	   (call .swaptools.subj_type_transition (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .stordev.read.type (subj))
+	   (call .stordev.read_all_blk_files (subj))
+	   (call .stordev.read_all_chr_files (subj))
+
+	   (call .zram.list_sysfile_dirs (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-growfs" file file_context)
+		  (filecon "/usr/lib/systemd/systemd-makefs" file
+			   file_context))))

--- a/src/agent/misc/systemd/systemdmodulesload.cil
+++ b/src/agent/misc/systemd/systemdmodulesload.cil
@@ -1,0 +1,114 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .systemd.modulesload.conf.conf_file_type_transition_file (typeattr))
+    (call .systemd.modulesload.data.lib_file_type_transition_file (typeattr))
+    (call .systemd.modulesload.run.run_file_type_transition_file (typeattr)))
+
+(in systemd
+
+    (block modulesload
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call data.list_file_dirs (subj))
+	   (call data.read_file_files (subj))
+
+	   (call run.list_file_dirs (subj))
+	   (call run.read_file_files (subj))
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .kmod.map_file_files (subj))
+	   (call .kmod.read_file_files (subj))
+
+	   (call .kmod.conf.list_file_dirs (subj))
+	   (call .kmod.conf.read_file_files (subj))
+
+	   (call .kmod.data.list_file_dirs (subj))
+	   (call .kmod.data.read_file_files (subj))
+
+	   (call .kmod.subj_type_transition (subj))
+
+	   (call .mod.search_file_dirs (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sysctl.subj_type_transition (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block conf
+
+		  (filecon "/etc/modules-load\.d" dir file_context)
+		  (filecon "/etc/modules-load\.d/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "modules-load.d")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block data
+
+		  (filecon "/usr/lib/modules-load\.d" dir file_context)
+		  (filecon "/usr/lib/modules-load\.d/.*" any file_context)
+
+		  (macro lib_file_type_transition_file ((type ARG1))
+			 (call .lib.file_type_transition
+			       (ARG1 file dir "modules-load.d")))
+
+		  (blockinherit .file.data.base_template)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-modules-load" file
+			   file_context))
+
+	   (block run
+
+		  (filecon "/run/modules-load\.d" dir file_context)
+		  (filecon "/run/modules-load\.d/.*" any file_context)
+
+		  (macro run_file_type_transition_file ((type ARG1))
+			 (call .run.file_type_transition
+			       (ARG1 file dir "modules-load.d")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.run.template))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/system/kmod\.service.*" file
+			   file_context)
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-modules-load\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdnetworkgen.cil
+++ b/src/agent/misc/systemd/systemdnetworkgen.cil
@@ -1,0 +1,25 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block networkgen
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon
+		   "/usr/lib/systemd/systemd-network-generator" file
+		   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-network-generator\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdpstore.cil
+++ b/src/agent/misc/systemd/systemdpstore.cil
@@ -1,0 +1,32 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.pstore
+
+    (blockinherit .sys.agent.template)
+
+    (call conf.list_file_dirs (subj))
+    (call conf.read_file_files (subj))
+
+    (call data.list_file_dirs (subj))
+    (call data.read_file_files (subj))
+
+    (call run.list_file_dirs (subj))
+    (call run.read_file_files (subj))
+
+    (call state.manage_file_files (subj))
+    (call state.readwrite_file_dirs (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-pstore" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-pstore\.service.*" file
+		    file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdquotacheck.cil
+++ b/src/agent/misc/systemd/systemdquotacheck.cil
@@ -1,0 +1,43 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.quotacheck
+
+    (blockinherit .sys.agent.template)
+
+    (allow subj self create_unix_dgram_socket)
+
+    (call run.manage_file_files (subj))
+    (call run.systemd_run_file_type_transition_file (subj))
+
+    (call systemd.logparsenv.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .quotacheck.subj_type_transition (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-quotacheck" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-quotacheck\.service.*" file
+		    file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdrandomseed.cil
+++ b/src/agent/misc/systemd/systemdrandomseed.cil
@@ -1,0 +1,55 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.randomseed
+
+    (blockinherit .sys.agent.template)
+
+    (allow subj self create_unix_dgram_socket)
+
+    (call state.manage_file_files (subj))
+    (call state.systemd_state_file_type_transition_file (subj))
+
+    (call systemd.logparsenv.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call systemd.state.create_file_dirs (subj))
+    (call systemd.state.state_file_type_transition_file (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .machineid.read_file_files (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .random.readwrite_nodedev_chr_files (subj))
+
+    (call .random.read_sysctlfile_pattern.type (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (call .state.create_file_dirs (subj))
+    (call .state.var_file_type_transition_file (subj))
+
+    (call .xattr.getattr_fs_pattern.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-random-seed" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-random-seed\.service.*"
+		    file file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdremountfs.cil
+++ b/src/agent/misc/systemd/systemdremountfs.cil
@@ -1,0 +1,53 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block remountfs
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (capability (sys_resource)))
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .fstab.read_file_files (subj))
+
+	   (call .mount.subj_type_transition (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .random.read_nodedev_chr_files (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-remount-fs" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-remount-fs\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdreplypassword.cil
+++ b/src/agent/misc/systemd/systemdreplypassword.cil
@@ -1,0 +1,16 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block replypassword
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-reply-password" file
+			   file_context))))

--- a/src/agent/misc/systemd/systemdrfkill.cil
+++ b/src/agent/misc/systemd/systemdrfkill.cil
@@ -1,0 +1,64 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.rfkill
+
+    (blockinherit .sys.agent.template)
+
+    (allow subj self create_netlink_kobject_uevent_socket)
+    (allow subj self create_unix_dgram_socket)
+
+    (call state.manage_file_files (subj))
+    (call state.readwrite_file_dirs (subj))
+
+    (call systemd.logparsenv.type (subj))
+    (call systemd.notify.type (subj))
+
+    (call systemd.state.search_file_pattern.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call systemd.udev.run.read_file_pattern.type (subj))
+
+    (call .bus.search_sysfile_pattern.type (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .class.traverse_sysfile_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .devices.read_sysfile_files (subj))
+    (call .devices.traverse_sysfile_pattern.type (subj))
+
+    (call .event.readwrite_nodedev_chr_files (subj))
+
+    (call .firmware.search_sysfile_pattern.type (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .rfkill.readwrite_nodedev_chr_files (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (call .xattr.getattr_fs_pattern.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-rfkill" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-rfkill\.service.*" file
+		    file_context)
+	   (filecon "/usr/lib/systemd/system/systemd-rfkill\.socket.*" file
+		    file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdsleep.cil
+++ b/src/agent/misc/systemd/systemdsleep.cil
@@ -1,0 +1,83 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in exec
+
+    (filecon "/usr/lib/systemd/system-sleep/.*" file file_context))
+
+(in systemd.sleep
+
+    (blockinherit .dbus.client.template)
+    (blockinherit .sys.agent.template)
+
+    (allow subj self (capability (sys_resource)))
+    (allow subj self create_unix_dgram_socket)
+    (allow subj self create_unix_stream_socket)
+
+    (call conf.list_file_dirs (subj))
+    (call conf.read_file_files (subj))
+
+    (call data.list_file_dirs (subj))
+    (call data.read_file_files (subj))
+
+    (call run.list_file_dirs (subj))
+    (call run.read_file_files (subj))
+
+    (call systemd.logparsenv.type (subj))
+
+    (call systemd.conf.search_file_pattern.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .dev.list_file_pattern.type (subj))
+
+    (call .exec.execute_file_files (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .power.write_sysfile_files (subj))
+    (call .power.search_sysfile_dirs (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .random.read_nodedev_chr_files (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (call .shell.exec.mapexecute_file_files (subj))
+    (call .shell.exec.read_file_files (subj))
+
+    (call .stordev.getattr_all_blk_files (subj))
+    (call .stordev.getattr_all_chr_files (subj))
+
+    (call .xattr.getattr_fs_pattern.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-sleep" file file_context))
+
+    (block unit
+
+	   (filecon
+	    "/usr/lib/systemd/system/systemd-hybrid-sleep\.service.*" file
+	    file_context)
+	   (filecon
+	    "/usr/lib/systemd/system/systemd-hibernate\.service.*" file
+	    file_context)
+	   (filecon
+	    "/usr/lib/systemd/system/systemd-suspend\.service.*" file
+	    file_context)
+	   (filecon
+	    "/usr/lib/systemd/system/systemd-suspend-then-hibernate\.service.*"
+	    file file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdstdiobridge.cil
+++ b/src/agent/misc/systemd/systemdstdiobridge.cil
@@ -1,0 +1,51 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block stdiobridge
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .user.agent.template)
+
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+
+	   (call systemd.hostname.sendmsg_subj_dbus.type (subj))
+
+	   (call .systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.login.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.network.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.resolve.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.timedate.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.timesync.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.unit.run.control_file_services (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .file.unit.control_all_services (subj))
+
+	   (call .fstab.status_file_services (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.control_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.status_self (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-stdio-bridge" file file_context))))

--- a/src/agent/misc/systemd/systemdsysusers.cil
+++ b/src/agent/misc/systemd/systemdsysusers.cil
@@ -1,0 +1,181 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .systemd.sysusers.conf.conf_file_type_transition_file (typeattr))
+    (call .systemd.sysusers.data.lib_file_type_transition_file (typeattr))
+    (call .systemd.sysusers.run.run_file_type_transition_file (typeattr)))
+
+(in systemd
+
+    (block sysusers
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self
+		  (capability (dac_override dac_read_search sys_admin
+					    sys_resource)))
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_netlink_kobject_uevent_socket)
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call data.list_file_dirs (subj))
+	   (call data.read_file_files (subj))
+
+	   (call run.list_file_dirs (subj))
+	   (call run.read_file_files (subj))
+
+	   (call tmp.manage_file_dirs (subj))
+	   (call tmp.mounton_file_dirs (subj))
+	   (call tmp.tmp_file_type_transition_file (subj))
+
+	   (call systemd.dynamicuser.type (subj))
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .bus.search_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .conf.deletename_file_dirs (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_pattern.type (subj))
+
+	   (call .file.auth.write.type (subj))
+
+	   (call .fsck.subj_type_transition (subj))
+
+	   (call .ibac.objchangesys.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .logindefs.read_file_files (subj))
+
+	   (call .loop.readwrite_stordev_blk_files (subj))
+
+	   (call .loopcontrol.readwrite_nodedev_chr_files (subj))
+
+	   (call .mount.image.readwrite_all_files (subj))
+	   (call .mount.image.search_all_dirs (subj))
+
+	   (call .nss.linked.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .passwd.manage_file_files (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .pwdlock.conf_file_type_transition_file (subj "*"))
+	   (call .pwdlock.manage_file_files (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbac.objchangesys.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .root.mounton_file_dirs (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .shadow.manage_file_files (subj))
+	   (call .shadow.read.type (subj))
+
+	   (call .state.search_file_pattern.type (subj))
+
+	   (call .stordev.readwrite.type (subj))
+
+	   (call .sys.dontaudit_setsched_subj_processes (subj))
+
+	   (call .terminfo.read_file_pattern.type (subj))
+
+	   (call .tmp.deletename_file_dirs (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+	   (call .xattr.mount_fs (subj))
+	   (call .xattr.unmount_fs (subj))
+
+	   (optional systemdsysusers_systemdnspawn
+		     (call .systemd.nspawn.container.obj.manage_all_dirs
+			   (subj))
+		     (call .systemd.nspawn.container.obj.manage_all_files
+			   (subj))
+		     (call .systemd.nspawn.container.obj.manage_all_lnk_files
+			   (subj)))
+
+	   (block conf
+
+		  (filecon "/etc/sysusers\.d" dir file_context)
+		  (filecon "/etc/sysusers\.d/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "sysusers.d")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block data
+
+		  (filecon "/usr/lib/sysusers\.d" dir file_context)
+		  (filecon "/usr/lib/sysusers\.d/.*" any file_context)
+
+		  (macro lib_file_type_transition_file ((type ARG1))
+			 (call .lib.file_type_transition
+			       (ARG1 file dir "sysusers.d")))
+
+		  (blockinherit .file.data.base_template)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-sysusers" file file_context))
+
+	   (block run
+
+		  (filecon "/run/sysusers\.d" dir file_context)
+		  (filecon "/run/sysusers\.d/.*" any file_context)
+
+		  (macro run_file_type_transition_file ((type ARG1))
+			 (call .run.file_type_transition
+			       (ARG1 file dir "sysusers.d")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.run.base_template))
+
+	   (block tmp
+
+		  (macro tmp_file_type_transition_file ((type ARG1))
+			 (call .tmp.file_type_transition
+			       (ARG1 file dir "*")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.tmp.base_template))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/system/systemd-sysusers\.service.*"
+			   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdtimedate.cil
+++ b/src/agent/misc/systemd/systemdtimedate.cil
@@ -1,0 +1,85 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block timedate
+
+	   (blockinherit .dbus.nameclient.template)
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (capability (sys_time)))
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.notify.type (subj))
+
+	   (call systemd.conf.search_file_pattern.type (subj))
+
+	   (call systemd.ntpunits.conf.list_file_dirs (subj))
+	   (call systemd.ntpunits.conf.read_file_files (subj))
+	   (call systemd.ntpunits.data.list_file_dirs (subj))
+	   (call systemd.ntpunits.data.read_file_files (subj))
+	   (call systemd.ntpunits.run.list_file_dirs (subj))
+	   (call systemd.ntpunits.run.read_file_files (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.timesync.unit.control_file_services (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .clock.read_nodedev_chr_files (subj))
+
+	   (call .conf.manage_file_lnk_files (subj))
+	   (call .conf.readwrite_file_dirs (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .hwclock.conf.manage_file_files (subj))
+	   (call .hwclock.conf.conf_file_type_transition_file (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .sys.reload_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.status_system (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdtimedate_polkit
+		     (call .polkit.sendmsg_subj_dbus.type (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-timedated" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-timedated\.service.*" file
+		   file_context)
+
+		  (blockinherit .file.unit.template)
+
+		  (call .dbus.activated.unit.type (file)))))

--- a/src/agent/misc/systemd/systemdtimesync.cil
+++ b/src/agent/misc/systemd/systemdtimesync.cil
@@ -1,0 +1,84 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.timesync
+
+    (blockinherit .dbus.nameclient.template)
+    (blockinherit .sys.agent.template)
+
+    (allow subj self (capability (sys_time)))
+    (allow subj self (process (setfscreate)))
+    (allow subj self create_unix_dgram_socket)
+
+    (call conf.list_file_dirs (subj))
+    (call conf.read_file_files (subj))
+
+    (call data.list_file_dirs (subj))
+    (call data.read_file_files (subj))
+
+    (call run.manage_file_dirs (subj))
+    (call run.manage_file_files (subj))
+    (call run.systemd_run_file_type_transition_file (subj))
+
+    (call state.manage_file_files (subj))
+    (call state.readwrite_file_dirs (subj))
+
+    (call systemd.logparsenv.type (subj))
+    (call systemd.notify.type (subj))
+
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call systemd.netif.run.list_file_dirs (subj))
+    (call systemd.netif.run.read_file_files (subj))
+    (call systemd.netif.run.watch_file_dirs (subj))
+
+    (call systemd.state.search_file_pattern.type (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .dbus.run.listinherited_file_dirs (subj))
+    (call .dbus.run.readinherited_file_sock_files (subj))
+    (call .dbus.run.watch_file_dirs (subj))
+    (call .dbus.run.watch_file_sock_files (subj))
+
+    (call .hwclock.conf.read_file_files (subj))
+
+    (call .nss.hosts.type (subj))
+    (call .nss.passwdgroup.type (subj))
+
+    (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+    (call .overcommitmemory.read_sysctlfile_pattern.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .random.read_sysctlfile_pattern.type (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .root.list_file_dirs (subj))
+    (call .root.watch_file_dirs (subj))
+
+    (call .run.list_file_dirs (subj))
+    (call .run.watch_file_dirs (subj))
+
+    (call .selinux.file.read_file_pattern.type (subj))
+    (call .selinux.mapread_fs_pattern.type (subj))
+
+    (call .xattr.getattr_fs_pattern.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-timesyncd" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-timesyncd\.service.*" file
+		    file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/systemd/systemdtimewaitsync.cil
+++ b/src/agent/misc/systemd/systemdtimewaitsync.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block timewaitsync
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-time-wait-sync" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-time-wait-sync\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdupdateutmp.cil
+++ b/src/agent/misc/systemd/systemdupdateutmp.cil
@@ -1,0 +1,65 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block updateutmp
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (capability (audit_write)))
+	   (allow subj self create_netlink_audit_socket)
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+	   (allow subj self (netlink_audit_socket (nlmsg_relay)))
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.private.type (subj))
+
+	   (call systemd.unit.status_file_services (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.suloginshell.unit.status_file_services (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .log.search_file_pattern.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.status_system (subj))
+
+	   (call .utmp.log.write_file_files (subj))
+	   (call .utmp.run.manage_file_files (subj))
+	   (call .utmp.run.run_file_type_transition_file (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-update-utmp" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-update-utmp-runlevel\.service.*"
+		   file file_context)
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-update-utmp\.service.*" file
+		   file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdusersessions.cil
+++ b/src/agent/misc/systemd/systemdusersessions.cil
@@ -1,0 +1,51 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block usersessions
+
+	   (blockinherit .sys.agent.template)
+
+	   (allow subj self (process (setfscreate)))
+	   (allow subj self create_unix_dgram_socket)
+
+	   (call systemd.logparsenv.type (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .nologin.manage_file_files (subj))
+	   (call .nologin.run_file_type_transition_file (subj "*"))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .run.deletename_file_dirs (subj))
+
+	   (call .selinux.file.read_file_pattern.type (subj))
+	   (call .selinux.mapread_fs_pattern.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-user-sessions" file
+			   file_context))
+
+	   (block unit
+
+		  (filecon
+		   "/usr/lib/systemd/system/systemd-user-sessions\.service.*"
+		   file file_context)
+
+		  (blockinherit .file.unit.template))))

--- a/src/agent/misc/systemd/systemdveritysetup.cil
+++ b/src/agent/misc/systemd/systemdveritysetup.cil
@@ -1,0 +1,16 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block veritysetup
+
+	   (blockinherit .sys.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/lib/systemd/systemd-veritysetup" file
+			   file_context))))

--- a/src/agent/misc/systemd/systemdvolatileroot.cil
+++ b/src/agent/misc/systemd/systemdvolatileroot.cil
@@ -1,0 +1,20 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.volatileroot
+
+    (blockinherit .sys.agent.template)
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/lib/systemd/systemd-volatile-root" file file_context))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/systemd-volatile-root\.service.*"
+		    file file_context)
+
+	   (blockinherit .file.unit.template)))

--- a/src/agent/misc/utillinux/fstrim.cil
+++ b/src/agent/misc/utillinux/fstrim.cil
@@ -1,0 +1,40 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block fstrim
+
+       (blockinherit .sys.agent.template)
+
+       (allow subj self (capability (dac_override dac_read_search sys_admin)))
+
+       (call .block.traverse_sysfile_pattern.type (subj))
+
+       (call .dev.traverse_sysfile_pattern.type (subj))
+
+       (call .devices.list_sysfile_pattern.type (subj))
+       (call .devices.read_sysfile_files (subj))
+
+       (call .fstab.read_file_files (subj))
+
+       (call .locale.data.map_file_pattern.type (subj))
+       (call .locale.read_file_pattern.type (subj))
+
+       (call .mount.mountpoint.readwrite_all_dirs (subj))
+
+       (call .stordev.getattr_all_blk_files (subj))
+       (call .stordev.getattr_all_chr_files (subj))
+
+       (call .selinux.linked.type (subj))
+
+       (block exec
+
+	      (filecon "/usr/bin/fstrim" file file_context))
+
+       (block unit
+
+	      (filecon "/usr/lib/systemd/system/fstrim\.service.*" file
+		       file_context)
+	      (filecon "/usr/lib/systemd/system/fstrim\.timer.*" file
+		       file_context)
+
+	      (blockinherit .file.unit.template)))

--- a/src/agent/misc/utillinux/login.cil
+++ b/src/agent/misc/utillinux/login.cil
@@ -55,18 +55,20 @@
 
        (call .user.run.search_file_pattern.type (subj))
 
-       (call .user.termdev.readwrite_all_chr_files (subj))
-       (call .user.termdev.relabel_all_chr_files (subj))
-       (call .user.termdev.setattr_all_chr_files (subj))
-
-       (call .user.unpriv.create_all_keyrings (subj))
-       (call .user.unpriv.rlimitinh_all_processes (subj))
-       (call .user.unpriv.signal_all_processes (subj))
-       (call .user.unpriv.signull_all_processes (subj))
-       (call .user.unpriv.transition_all_processes (subj))
-       (call .user.unpriv.write_all_keyrings (subj))
-
        (call .xattr.getattr_fs_pattern.type (subj))
+
+       (optional login_unprivuser
+		 (call .user.unpriv.create_all_keyrings (subj))
+		 (call .user.unpriv.rlimitinh_all_processes (subj))
+		 (call .user.unpriv.signal_all_processes (subj))
+		 (call .user.unpriv.signull_all_processes (subj))
+		 (call .user.unpriv.transition_all_processes (subj))
+		 (call .user.unpriv.write_all_keyrings (subj)))
+
+       (optional login_usertermdev
+		 (call .user.termdev.readwrite_all_chr_files (subj))
+		 (call .user.termdev.relabel_all_chr_files (subj))
+		 (call .user.termdev.setattr_all_chr_files (subj)))
 
        (block exec
 

--- a/src/agent/misc/utillinux/losetup.cil
+++ b/src/agent/misc/utillinux/losetup.cil
@@ -1,0 +1,31 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block losetup
+
+       (blockinherit .sys.agent.template)
+
+       (call .block.search_sysfile_pattern.type (subj))
+
+       (call .debug.search_fs_pattern.type (subj))
+
+       (call .locale.data.map_file_pattern.type (subj))
+       (call .locale.read_file_pattern.type (subj))
+
+       (call .loop.readwrite_stordev_blk_files (subj))
+
+       (call .loopcontrol.readwrite_nodedev_chr_files (subj))
+
+       (call .mount.image.readwrite_all_files (subj))
+       (call .mount.image.search_all_dirs (subj))
+
+       (call .rbacsep.constrained.type (subj))
+       (call .rbacsep.usefdsource.type (subj))
+
+       (call .state.search_file_pattern.type (subj))
+
+       (call .stordev.readwrite.type (subj))
+
+       (block exec
+
+	      (filecon "/usr/bin/losetup" file file_context)))

--- a/src/agent/misc/utillinux/parttools.cil
+++ b/src/agent/misc/utillinux/parttools.cil
@@ -1,0 +1,40 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block parttools
+
+       (blockinherit .sys.agent.template)
+
+       (allow subj self (capability (sys_admin)))
+
+       (call .dev.traverse_sysfile_pattern.type (subj))
+
+       (call .devices.read_sysfile_pattern.type (subj))
+
+       (call .inputrc.conf.read_file_files (subj))
+
+       (call .locale.data.map_file_pattern.type (subj))
+       (call .locale.read_file_pattern.type (subj))
+
+       (call .mount.image.readwrite_all_files (subj))
+       (call .mount.image.search_all_dirs (subj))
+
+       (call .rbacsep.constrained.type (subj))
+       (call .rbacsep.usefdsource.type (subj))
+
+       (call .state.search_file_pattern.type (subj))
+
+       (call .stordev.readwrite.type (subj))
+       (call .stordev.readwrite_all_blk_files (subj))
+
+       (call .terminfo.read_file_pattern.type (subj))
+
+       (block exec
+
+	      (filecon "/usr/bin/addpart" file file_context)
+	      (filecon "/usr/bin/cfdisk" file file_context)
+	      (filecon "/usr/bin/delpart" file file_context)
+	      (filecon "/usr/bin/fdisk" file file_context)
+	      (filecon "/usr/bin/partx" file file_context)
+	      (filecon "/usr/bin/resizepart" file file_context)
+	      (filecon "/usr/bin/sfdisk" file file_context)))

--- a/src/agent/sysagent/q/quotacheck.cil
+++ b/src/agent/sysagent/q/quotacheck.cil
@@ -1,0 +1,97 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block quotacheck
+
+       (filecon "HOME_ROOT/aquota\.(user|group)" file file_context)
+
+       (filecon "/aquota\.(user|group)" file file_context)
+
+       (macro getattr_file_files ((type ARG1))
+	      (allow ARG1 file (file (getattr))))
+
+       (macro home_file_type_transition_file ((type ARG1))
+	      (call .home.file_type_transition
+		    (ARG1 file file "aquota.group"))
+	      (call .home.file_type_transition
+		    (ARG1 file file "aquota.group.new"))
+	      (call .home.file_type_transition
+		    (ARG1 file file "aquota.user"))
+	      (call .home.file_type_transition
+		    (ARG1 file file "aquota.user.new")))
+
+       (macro quotaon_file_files ((type ARG1))
+	      (allow ARG1 file (file (quotaon))))
+
+       (macro root_file_type_transition_file ((type ARG1))
+	      (call .root.file_type_transition
+		    (ARG1 file file "aquota.group"))
+	      (call .root.file_type_transition
+		    (ARG1 file file "aquota.group.new"))
+	      (call .root.file_type_transition
+		    (ARG1 file file "aquota.user"))
+	      (call .root.file_type_transition
+		    (ARG1 file file "aquota.user.new")))
+
+       (blockinherit .file.base_template)
+       (blockinherit .file.macro_template_files)
+       (blockinherit .sys.agent.template)
+
+       (allow subj self
+	      (capability (dac_read_search dac_override linux_immutable
+					   sys_admin)))
+
+       (call home_file_type_transition_file (subj))
+       (call manage_file_files (subj))
+       (call quotaon_file_files (subj))
+
+       (call bootflag.manage_file_files (subj))
+       (call bootflag.root_file_type_transition_file (subj))
+
+       (call .fs.read_sysctlfile_files (subj))
+       (call .fs.search_sysctlfile_pattern.type (subj))
+
+       (call .file.read_all_file (subj))
+
+       (call .home.deletename_file_dirs (subj))
+
+       (call .rbacsep.constrained.type (subj))
+       (call .rbacsep.usefdsource.type (subj))
+
+       (call .root.deletename_file_dirs (subj))
+
+       (call .shadow.read.type (subj))
+
+       (call .stordev.read.type (subj))
+       (call .stordev.read_all_blk_files (subj))
+       (call .stordev.read_all_chr_files (subj))
+
+       (call .sys.dontaudit_setsched_subj_processes (subj))
+
+       (call .xattr.associate_fs_pattern.type (file))
+
+       (call .xattr.getattr_fs_pattern.type (subj))
+       (call .xattr.quotaget_fs (subj))
+       (call .xattr.quotamod_fs (subj))
+       (call .xattr.remount_fs (subj))
+
+       (block bootflag
+
+	      (filecon "/forcequotacheck" file file_context)
+
+	      (macro root_file_type_transition_file ((type ARG1))
+		     (call .root.file_type_transition
+			   (ARG1 file file "forcequotacheck")))
+
+	      (blockinherit .file.bootflag.template))
+
+       (block exec
+
+	      (filecon "/usr/bin/quotacheck" file file_context)))
+
+(in file.unconfined
+
+    (call .quotacheck.bootflag.root_file_type_transition_file (typeattr))
+
+    (call .quotacheck.home_file_type_transition_file (typeattr))
+    (call .quotacheck.root_file_type_transition_file (typeattr)))

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -2083,6 +2083,9 @@
 
 	   (typeattribute typeattr)
 
+	   ;; for compat
+	   (allow typeattr self create_netlink_selinux_socket)
+
 	   (call map_fs_files (typeattr))
 	   (call read_fs_files (typeattr))
 	   (call search_fs_pattern.type (typeattr)))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -116,6 +116,33 @@
     (optional unprivuser_ping
 	      (call .ping.role (role)))
 
+    (optional unprivuser_opensshclient
+	      (call .openssh.add.role (role))
+	      (call .openssh.add.tmp.manage_file_files (subj))
+	      (call .openssh.add.tmp.relabel_file_files (subj))
+	      (call .openssh.agent.role (role))
+	      (call .openssh.agent.run.manage_file_sock_files (subj))
+	      (call .openssh.agent.run.relabel_file_sock_files (subj))
+	      (call .openssh.agent.run.user_run_file_type_transition_file
+		    (subj))
+	      (call .openssh.agent.tmp.manage_file_dirs (subj))
+	      (call .openssh.agent.tmp.manage_file_sock_files (subj))
+	      (call .openssh.agent.tmp.relabel_file_dirs (subj))
+	      (call .openssh.agent.tmp.relabel_file_sock_files (subj))
+	      (call .openssh.client.role (role))
+	      (call .openssh.client.tmp.manage_file_sock_files (subj))
+	      (call .openssh.client.tmp.relabel_file_sock_files (subj))
+	      (call .openssh.home.manage_file_dirs (subj))
+	      (call .openssh.home.manage_file_files (subj))
+	      (call .openssh.home.relabel_file_dirs (subj))
+	      (call .openssh.home.relabel_file_files (subj))
+	      (call .openssh.home.user_home_file_type_transition_file (subj))
+	      (call .openssh.keygen.role (role))
+	      (call .openssh.keysign.role (role)))
+
+    (optional unprivuser_opensshsftpserver
+	      (call .openssh.sftpserver.role (role)))
+
     (optional unprivuser_usermailfile
 	      (call mail.manage_file_pattern.type (subj))
 	      (call mail.map_file_files (subj))
@@ -155,6 +182,15 @@
 	   (call .subj.useinteractivefd.type (typeattr))
 
 	   (call .unixchkpwd.role (roleattr))
+
+	   (optional unprivuser_unpriv_opensshserver
+		     (call .openssh.server.ptytermdev_type_change
+			   (typeattr ptytermdev))
+		     (call .openssh.server.readwriteinherited_subj_fifo_files
+			   (typeattr))
+		     (call .openssh.server.use_subj_fds (typeattr))
+
+		     (call .rbacsep.exemptsource.type (typeattr)))
 
 	   (block role_template
 

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -83,6 +83,8 @@
 
     (call .systemd.askpassword.client.role (role))
 
+    (call .systemd.stdiobridge.role (role))
+
     (call .systemd.systemctl.noatsecure_subj_processes (subj))
     (call .systemd.systemctl.role (role))
 
@@ -182,6 +184,7 @@
 	   (call .subj.useinteractivefd.type (typeattr))
 
 	   (call .unixchkpwd.role (roleattr))
+	   (call .unixupdate.role (roleattr))
 
 	   (optional unprivuser_unpriv_opensshserver
 		     (call .openssh.server.ptytermdev_type_change

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -11,6 +11,8 @@
 
        (call .systemd.askpassword.client.role (role))
 
+       (call .systemd.stdiobridge.role (role))
+
        (call .systemd.systemctl.role (role))
 
        (optional wheeluser_consolesetupcon

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -19,5 +19,15 @@
        (optional wheeluser_mount
 		 (call .mount.role (role)))
 
+       (optional wheeluser_opensshclient
+		 (call .openssh.add.role (role))
+		 (call .openssh.agent.role (role))
+		 (call .openssh.client.role (role))
+		 (call .openssh.keygen.role (role))
+		 (call .openssh.keysign.role (role)))
+
+       (optional wheeluser_opensshsftpserver
+		 (call .openssh.sftpserver.role (role)))
+
        (optional wheeluser_ping
 		 (call .ping.role (role))))


### PR DESCRIPTION
- make confined users optional to openssh
- login should not depend on confined users
- adds fstrim
- add losetup
- adds parttools
- adds service
- adds systemd timesync
- adds systemd timedate
- adds systemd modules-load
- adds systemd backlight
- adds systemd binfmt
- adds systemd bless-boot
- adds systemd boot-check-no-failures
- adds systemd cgroups-agent
- adds systemd crypt-setup
- adds systemd hibernate-resume
- adds systemd hwdb-update
- deal with this in a central place (might not need it)
- adds systemd locale
- adds systemd sleep
- adds systemd initctl
- adds systemd machine-id-setup
- adds systemd makefs/growfs
- adds systemd ac-power
- adds systemd network generator
- adds systemd pstore
- adds quotacheck and systemd quotacheck
- adds systemd random-seed
- adds systemd remount-fs
- adds systemd reply-password
- adds systemd rfkill
- adds systemd stdio-bridge
- adds systemd sysusers
- adds systemd time-wait-sync
- adds systemd update-done
- adds systemd user-sessions
- adds system verity-setup
- adds systemd volatile-root
