### PR TITLE
modular

### DIFF
--- a/src/agent/misc/systemd/systemdmodulesload.cil
+++ b/src/agent/misc/systemd/systemdmodulesload.cil
@@ -62,12 +62,17 @@
 
 	   (block conf
 
+		  (filecon "/etc/modules" file file_context)
+		  (filecon "/etc/modules\..*" file file_context)
+
 		  (filecon "/etc/modules-load\.d" dir file_context)
 		  (filecon "/etc/modules-load\.d/.*" any file_context)
 
 		  (macro conf_file_type_transition_file ((type ARG1))
 			 (call .conf.file_type_transition
-			       (ARG1 file dir "modules-load.d")))
+			       (ARG1 file dir "modules-load.d"))
+			 (call .conf.file_type_transition
+			       (ARG1 file file "modules")))
 
 		  (blockinherit .file.conf.template))
 

--- a/src/agent/misc/systemd/systemdtimesync.cil
+++ b/src/agent/misc/systemd/systemdtimesync.cil
@@ -74,7 +74,10 @@
 
     (block exec
 
-	   (filecon "/usr/lib/systemd/systemd-timesyncd" file file_context))
+	   (filecon "/usr/lib/systemd/systemd-timesyncd" file file_context)
+
+	   (macro auditexecuteaccess_file_files ((type ARG1))
+		  (allow ARG1 file (file (execute getattr)))))
 
     (block unit
 

--- a/src/agent/sysagent/d/dhclient.cil
+++ b/src/agent/sysagent/d/dhclient.cil
@@ -126,6 +126,8 @@
 
 	      (call .systemd.run.search_file_dirs (subj))
 
+	      (call .systemd.timesync.exec.auditexecuteaccess_file_files (subj))
+
 	      (call .systemd.unit.run.search_file_dirs (subj))
 
 	      (block exec


### PR DESCRIPTION
- make confined users optional to openssh
- login should not depend on confined users
- adds fstrim
- add losetup
- adds parttools
- adds service
- adds systemd timesync
- adds systemd timedate
- adds systemd modules-load
- adds systemd backlight
- adds systemd binfmt
- adds systemd bless-boot
- adds systemd boot-check-no-failures
- adds systemd cgroups-agent
- adds systemd crypt-setup
- adds systemd hibernate-resume
- adds systemd hwdb-update
- deal with this in a central place (might not need it)
- adds systemd locale
- adds systemd sleep
- adds systemd initctl
- adds systemd machine-id-setup
- adds systemd makefs/growfs
- adds systemd ac-power
- adds systemd network generator
- adds systemd pstore
- adds quotacheck and systemd quotacheck
- adds systemd random-seed
- adds systemd remount-fs
- adds systemd reply-password
- adds systemd rfkill
- adds systemd stdio-bridge
- adds systemd sysusers
- adds systemd time-wait-sync
- adds systemd update-done
- adds systemd user-sessions
- adds system verity-setup
- adds systemd volatile-root
- systemd modules-load and dhclient-script/systemd timesync
