### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/systemd/systemdjournalctl.cil
+++ b/src/agent/misc/systemd/systemdjournalctl.cil
@@ -1,0 +1,137 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block journalctl
+
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self (unix_dgram_socket (sendto)))
+	   (allow subj self create_netlink_kobject_uevent_socket)
+
+	   (call tmp.manage_file_dirs (subj))
+	   (call tmp.manage_file_files (subj))
+	   (call tmp.map_file_files (subj))
+	   (call tmp.mounton_file_dirs (subj))
+	   (call tmp.tmp_file_type_transition_file (subj))
+
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.catalog.data.list_file_dirs (subj))
+	   (call systemd.catalog.data.read_file_files (subj))
+	   (call systemd.catalog.state.manage_file_dirs (subj))
+	   (call systemd.catalog.state.manage_file_files (subj))
+	   (call systemd.catalog.state.map_file_files (subj))
+	   (call systemd.catalog.state.systemd_state_file_type_transition_file
+		 (subj))
+
+	   (call systemd.journal.connectto_subj_unix_stream_sockets (subj))
+
+	   (call systemd.journal.log.manage_file_dirs (subj))
+	   (call systemd.journal.log.manage_file_files (subj))
+	   (call systemd.journal.log.map_file_files (subj))
+	   (call systemd.journal.log.read_file_lnk_files (subj))
+	   (call systemd.journal.log.watch_file_dirs (subj))
+
+	   (call systemd.machines.run.read_file_files (subj))
+	   (call systemd.machines.run.search_file_dirs (subj))
+
+	   (call systemd.journal.relay_msgs.type (subj))
+
+	   (call systemd.journal.run.search_file_dirs (subj))
+	   (call systemd.journal.run.write_file_sock_files (subj))
+
+	   (call systemd.state.search_file_pattern.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .bus.search_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .debug.search_fs_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_pattern.type (subj))
+
+	   (call .fsck.subj_type_transition (subj))
+
+	   (call .kernel.read_sysfile_files (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .log.search_file_pattern.type (subj))
+
+	   (call .loop.readwrite_stordev_blk_files (subj))
+
+	   (call .loopcontrol.readwrite_nodedev_chr_files (subj))
+
+	   (call .mount.image.readwrite_all_files (subj))
+	   (call .mount.image.search_all_dirs (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .nss.passwdgroup.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_nodedev_chr_files (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .root.mounton_file_dirs (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .state.search_file_pattern.type (subj))
+
+	   (call .stordev.readwrite.type (subj))
+
+	   (call .sys.dontaudit_setsched_subj_processes (subj))
+
+	   (call .tmp.deletename_file_dirs (subj))
+	   (call .tmp.getattr_fs_pattern.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+	   (call .xattr.mount_fs (subj))
+	   (call .xattr.unmount_fs (subj))
+
+	   (optional systemdjournalctl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/journalctl" file file_context))
+
+	   (block tmp
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro tmp_file_type_transition_file ((type ARG1))
+			 (call .tmp.file_type_transition
+			       (ARG1 file dir "*"))
+			 (call .tmp.file_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.user.tmp.base_template))))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -83,6 +83,13 @@
 
     (call .systemd.askpassword.client.role (role))
 
+    (call .systemd.journalctl.role (role))
+    (call .systemd.journalctl.tmp.manage_file_dirs (subj))
+    (call .systemd.journalctl.tmp.manage_file_files (subj))
+    (call .systemd.journalctl.tmp.map_file_files (subj))
+    (call .systemd.journalctl.tmp.relabel_file_dirs (subj))
+    (call .systemd.journalctl.tmp.relabel_file_files (subj))
+
     (call .systemd.stdiobridge.role (role))
 
     (call .systemd.systemctl.noatsecure_subj_processes (subj))

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -11,6 +11,8 @@
 
        (call .systemd.askpassword.client.role (role))
 
+       (call .systemd.journalctl.role (role))
+
        (call .systemd.stdiobridge.role (role))
 
        (call .systemd.systemctl.role (role))


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
