### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/dbus/dbusdaemon.cil
+++ b/src/agent/misc/dbus/dbusdaemon.cil
@@ -53,6 +53,10 @@
 
 ;; system dbus-daemon specific method returns
 
+(optional systemdhostname_systemdanalyze
+
+	  (call systemd.analyze.sendmsg_subj_dbus.type (systemd.hostname.subj)))
+
 (optional systemdlogin_login
 
 	  (call login.sendmsg_subj_dbus.type (systemd.login.subj)))

--- a/src/agent/misc/systemd/systemdanalyze.cil
+++ b/src/agent/misc/systemd/systemdanalyze.cil
@@ -97,6 +97,8 @@
 
 	   (call .bus.search_sysfile_pattern.type (subj))
 
+	   (call .cache.search_file_pattern.type (subj))
+
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 
 	   (call .cgroup.getattr_fs_pattern.type (subj))
@@ -109,6 +111,7 @@
 	   (call .crypto.read_sysctlfile_pattern.type (subj))
 
 	   (call .data.list_file_dirs (subj))
+	   (call .data.read_file_lnk_files (subj))
 
 	   (call .dbus.client.type (subj))
 
@@ -175,6 +178,9 @@
 
 	   (call .selinux.linked.type (subj))
 
+	   (call .shell.exec.mapexecute_file_files (subj))
+	   (call .shell.exec.read_file_files (subj))
+
 	   (call .state.search_file_pattern.type (subj))
 
 	   (call .stordev.getattr_all_blk_files (subj))
@@ -202,6 +208,9 @@
 
 	   (call .user.run.search_file_pattern.type (subj))
 
+	   (call .user.slice.manage_cgroupfile_dirs (subj))
+	   (call .user.slice.readwrite_cgroupfile_files (subj))
+
 	   (call .xattr.getattr_fs_pattern.type (subj))
 
 	   (call .xdg.conf.read_file_lnk_files (subj))
@@ -210,6 +219,15 @@
 	   (call .zram.read_sysfile_files (subj))
 	   (call .zram.read_sysfile_lnk_files (subj))
 	   (call .zram.search_sysfile_dirs (subj))
+
+	   (optional systemdanalyze_groffconffile
+		     (call .groff.conf.list_file_dirs (subj))
+		     (call .groff.conf.read_file_files (subj)))
+
+	   (optional systemdanalyze_groffdatafile
+		     (call .groff.data.list_file_dirs (subj))
+		     (call .groff.data.read_file_files (subj))
+		     (call .groff.data.read_file_lnk_files (subj)))
 
 	   (optional systemdanalyze_opensshclient
 		     (call .openssh.client.subj_type_transition (subj)))

--- a/src/agent/misc/systemd/systemdsystemctl.cil
+++ b/src/agent/misc/systemd/systemdsystemctl.cil
@@ -89,9 +89,6 @@
 
 	   (call .rbac.objchangesys.type (subj))
 
-	   (call .rbacsep.constrained.type (subj))
-	   (call .rbacsep.readstatesource.type (subj))
-
 	   (call .selinux.file.read_file_pattern.type (subj))
 	   (call .selinux.mapread_fs_pattern.type (subj))
 
@@ -105,37 +102,14 @@
 	   (call .sys.sendmsg_subj_dbus.type (subj))
 	   (call .sys.status_self (subj))
 
+	   (call .sys.user.connectto_subj_unix_stream_sockets (subj))
+
 	   (call .tmp.getattr_fs_pattern.type (subj))
-
-	   (call .user.dbus.client.type (subj))
-
-	   (call .user.home.conf.search_file_pattern.type (subj))
 
 	   (call .user.run.search_file_pattern.type (subj))
 
 	   (call .user.slice.list_cgroupfile_dirs (subj))
 	   (call .user.slice.read_cgroupfile_files (subj))
-
-	   (call .user.systemd.agent (subj exec.file))
-	   (call .user.systemd.control_system (subj))
-	   (call .user.systemd.sendmsg_subj_dbus.type (subj))
-	   (call .user.systemd.service.noatsecure.type (subj))
-	   (call .user.systemd.private.type (subj))
-
-	   (call .user.systemd.home.conf.control_file_services (subj))
-	   (call .user.systemd.home.conf.manage_file_dirs (subj))
-	   (call .user.systemd.home.conf.manage_file_files (subj))
-	   (call .user.systemd.home.conf.manage_file_lnk_files (subj))
-
-	   (call .user.systemd.run.addname_file_dirs (subj))
-
-	   (call .user.systemd.unit.manage_file_dirs (subj))
-	   (call .user.systemd.unit.manage_file_lnk_files (subj))
-
-	   (call .user.systemd.unit.run.control_file_services (subj))
-	   (call .user.systemd.unit.run.manage_file_dirs (subj))
-	   (call .user.systemd.unit.run.manage_file_files (subj))
-	   (call .user.systemd.unit.run.manage_file_lnk_files (subj))
 
 	   (call .utmp.run.read_file_files (subj))
 
@@ -146,6 +120,30 @@
 
 	   (optional systemdsystemctl_polkit
 		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (optional systemdsystemctl_userdbus
+		     (call .user.dbus.client.type (subj)))
+
+	   (optional systemdsystemctl_userhomeconffile
+		     (call .user.home.conf.search_file_pattern.type (subj)))
+
+	   (optional systemdsystemctl_usersystemd
+		     (call .user.systemd.agent (subj exec.file))
+		     (call .user.systemd.control_system (subj))
+		     (call .user.systemd.home.conf.control_file_services (subj))
+		     (call .user.systemd.home.conf.manage_file_dirs (subj))
+		     (call .user.systemd.home.conf.manage_file_files (subj))
+		     (call .user.systemd.home.conf.manage_file_lnk_files (subj))
+		     (call .user.systemd.private.type (subj))
+		     (call .user.systemd.run.addname_file_dirs (subj))
+		     (call .user.systemd.sendmsg_subj_dbus.type (subj))
+		     (call .user.systemd.service.noatsecure.type (subj))
+		     (call .user.systemd.unit.manage_file_dirs (subj))
+		     (call .user.systemd.unit.manage_file_lnk_files (subj))
+		     (call .user.systemd.unit.run.control_file_services (subj))
+		     (call .user.systemd.unit.run.manage_file_dirs (subj))
+		     (call .user.systemd.unit.run.manage_file_files (subj))
+		     (call .user.systemd.unit.run.manage_file_lnk_files (subj)))
 
 	   (block exec
 

--- a/src/file/conffile/groffconffile.cil
+++ b/src/file/conffile/groffconffile.cil
@@ -1,0 +1,21 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .groff.conf.conf_file_type_transition_file (typeattr)))
+
+(in groff
+
+    (block conf
+
+	   (filecon "/etc/groff" dir file_context)
+	   (filecon "/etc/groff/.*" any file_context)
+
+	   (macro conf_file_type_transition_file ((type ARG1))
+		  (call .conf.file_type_transition
+			(ARG1 file dir "groff")))
+
+	   (blockinherit .file.conf.base_template)
+	   (blockinherit .file.macro_template_dirs)
+	   (blockinherit .file.macro_template_files)))

--- a/src/file/datafile/groffdatafile.cil
+++ b/src/file/datafile/groffdatafile.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block groff
+
+       (block data
+
+	      (filecon "/usr/share/groff" dir file_context)
+	      (filecon "/usr/share/groff/.*" any file_context)
+
+	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "groff")))
+
+	      (blockinherit .file.data.template)))
+
+(in file.unconfined
+
+    (call .groff.data.data_file_type_transition_file (typeattr)))

--- a/src/user.cil
+++ b/src/user.cil
@@ -50,6 +50,8 @@
 
 	   (call .auto.getattr_fs_dirs (typeattr))
 
+	   (call .cache.search_file_pattern.type (typeattr))
+
 	   (call .caplastcap.read_sysctlfile_pattern.type (typeattr))
 
 	   (call .computecreate_selinux_security (typeattr))
@@ -168,6 +170,15 @@
 	   (call .utmp.run.read_file_files (typeattr))
 
 	   (call .xattr.getattr_fs_pattern.type (typeattr))
+
+	   (optional user_common_groffconffile
+		     (call .groff.conf.list_file_dirs (typeattr))
+		     (call .groff.conf.read_file_files (typeattr)))
+
+	   (optional user_common_groffdatafile
+		     (call .groff.data.list_file_dirs (typeattr))
+		     (call .groff.data.read_file_files (typeattr))
+		     (call .groff.data.read_file_lnk_files (typeattr)))
 
 	   (optional user_common_misc
 		     (call .font.cache.map_file_pattern.type (typeattr))


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
- journalctl sets resource limits
- adds systemd analyze
- systemd analyze related
