### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/systemd/systemdanalyze.cil
+++ b/src/agent/misc/systemd/systemdanalyze.cil
@@ -8,7 +8,7 @@
 	   (blockinherit .dbus.client.macro_template)
 	   (blockinherit .hybrid.agent.template)
 
-	   (allow subj self (capability (sys_rawio)))
+	   (allow subj self (capability (sys_admin sys_rawio)))
 	   (allow subj self (capability2 (bpf perfmon)))
 	   (allow subj self (bpf (prog_load prog_run)))
 	   (allow subj self create_netlink_kobject_uevent_socket)
@@ -41,6 +41,8 @@
 
 	   (call systemd.coredump.data.list_file_dirs (subj))
 	   (call systemd.coredump.data.read_file_files (subj))
+
+	   (call systemd.data.search_file_dirs (subj))
 
 	   (call systemd.exec.execute_file_files (subj))
 
@@ -219,6 +221,10 @@
 	   (call .zram.read_sysfile_files (subj))
 	   (call .zram.read_sysfile_lnk_files (subj))
 	   (call .zram.search_sysfile_dirs (subj))
+
+	   ;; for /usr/lib/systemd//user-environment-generators/90gpg-agent
+	   (optional systemdanalyze_gnupg
+		     (call .gnupg.subj_type_transition (subj)))
 
 	   (optional systemdanalyze_groffconffile
 		     (call .groff.conf.list_file_dirs (subj))


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
- journalctl sets resource limits
- adds systemd analyze
- systemd analyze related
- systemd analyze
