### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/systemd/systemdbusctl.cil
+++ b/src/agent/misc/systemd/systemdbusctl.cil
@@ -1,0 +1,79 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block busctl
+
+	   (blockinherit .dbus.client.macro_template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.unit.run.status_file_services (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dbus.client.sendmsg_all_dbus.type (subj))
+	   (call .dbus.client.type (subj))
+
+	   (call .file.unit.status_all_services (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .fstab.status_file_services (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .nss.passwdgroup.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .subj.common.read_all_states (subj))
+	   (call .subj.dontaudit_read_all_states (subj))
+
+	   (call .sys.read_subj_states (subj))
+	   (call .sys.reload_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.start_system (subj))
+	   (call .sys.status_self (subj))
+	   (call .sys.status_system (subj))
+
+	   (call .tmp.getattr_fs_pattern.type (subj))
+
+	   (optional systemdbusctl_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdbusctl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (optional systemdbusctl_userdbus
+		     (call .user.dbus.client.sendmsg_all_dbus.type (subj))
+		     (call .user.dbus.client.type (subj)))
+
+	   (optional systemdbusctl_usersystemd
+		     (call .user.systemd.home.conf.status_file_services (subj))
+		     (call .user.systemd.reload_system (subj))
+		     (call .user.systemd.start_system (subj))
+		     (call .user.systemd.status_self (subj))
+		     (call .user.systemd.status_system (subj))
+		     (call .user.systemd.unit.run.status_file_services (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/busctl" file file_context))))

--- a/src/agent/misc/systemd/systemdcg.cil
+++ b/src/agent/misc/systemd/systemdcg.cil
@@ -1,0 +1,59 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block cg
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self (cap_userns (sys_ptrace)))
+	   (allow subj self create_unix_stream_socket)
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.pager.type (subj))
+	   (call systemd.private.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+	   (call .cgroup.list_fs_dirs (subj))
+	   (call .cgroup.read_fs_files (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .loadavg.read_procfile_files (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .meminfo.read_procfile_files (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .stat.read_procfile_files (subj))
+
+	   (call .subj.common.read_all_states (subj))
+	   (call .subj.dontaudit_read_all_states (subj))
+
+	   (call .sys.read_subj_states (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+
+	   (call .user.slice.list_cgroupfile_dirs (subj))
+	   (call .user.slice.read_cgroupfile_files (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-cgls" file file_context)
+		  (filecon "/usr/bin/systemd-cgtop" file file_context))))

--- a/src/agent/misc/systemd/systemdhostnamectl.cil
+++ b/src/agent/misc/systemd/systemdhostnamectl.cil
@@ -1,0 +1,51 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block hostnamectl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_unix_stream_socket)
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.hostname.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .machineid.read_file_files (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.status_system (subj))
+
+	   (optional systemdhostnamectl_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdhostnamectl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/hostnamectl" file file_context))))

--- a/src/agent/misc/systemd/systemdinhibit.cil
+++ b/src/agent/misc/systemd/systemdinhibit.cil
@@ -1,0 +1,105 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd.inhibit
+
+    (macro agent ((type ARG1)(type ARG2))
+	   (typetransition subj ARG2 process ARG1)
+	   (call service.exec.type (ARG2))
+	   (call service.type (ARG1)))
+
+    (blockinherit .dbus.client.template)
+    (blockinherit .hybrid.agent.template)
+
+    (call service.signal_all_processes (subj))
+    (call service.transition_all_processes (subj))
+
+    (call service.exec.mapexecute_all_files (subj))
+    (call service.exec.read_all_files (subj))
+
+    (call service.noatsecure.noatsecure_all_processes (subj))
+
+    (call systemd.pager.type (subj))
+
+    (call systemd.askpassword.client.type (subj))
+
+    (call systemd.login.inhibit.read_all_states (subj))
+    (call systemd.login.inhibit.type (subj))
+    (call systemd.login.sendmsg_subj_dbus.type (subj))
+
+    (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+    (call .cgroup.getattr_fs_pattern.type (subj))
+
+    (call .crypto.read_sysctlfile_pattern.type (subj))
+
+    (call .locale.data.map_file_pattern.type (subj))
+    (call .locale.read_file_pattern.type (subj))
+
+    (call .nss.passwdgroup.type (subj))
+
+    (call .proc.getattr_fs_pattern.type (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.readstatesource.type (subj))
+
+    (call .selinux.linked.type (subj))
+
+    (call .subj.dontaudit_read_all_states (subj))
+
+    (call .sys.read_subj_states (subj))
+
+    (optional systemdinhibit_exechomefile
+	      (call .user.exec_home_subj_type_transition (subj)))
+
+    (optional systemdinhibit_polkit
+	      (call .polkit.ttyagent.subj_type_transition (subj)))
+
+    (optional systemginhibit_unprivuser
+	      (call .user.exec_subj_type_transition (subj))
+	      (call .user.shell_exec_subj_type_transition (subj))
+	      (call .user.signal_subj_processes (subj)))
+
+    (block exec
+
+	   (filecon "/usr/bin/systemd-inhibit" file file_context))
+
+    (block service
+
+	   (macro signal_all_processes ((type ARG1))
+		  (allow ARG1 typeattr (process (signal))))
+
+	   (macro transition_all_processes ((type ARG1))
+		  (allow ARG1 typeattr (process (transition))))
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call use_subj_fds (typeattr))
+
+	   (call systemd.login.inhibit.type (typeattr))
+
+	   (block exec
+
+		  (macro mapexecute_all_files ((type ARG1))
+			 (allow ARG1 typeattr mapexecute_file))
+
+		  (macro read_all_files ((type ARG1))
+			 (allow ARG1 typeattr read_file))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (typeattribute typeattr))
+
+	   (block noatsecure
+
+		  (macro noatsecure_all_processes ((type ARG1))
+			 (allow ARG1 subj (process (noatsecure))))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (typeattribute typeattr))))

--- a/src/agent/misc/systemd/systemdlocalectl.cil
+++ b/src/agent/misc/systemd/systemdlocalectl.cil
@@ -1,0 +1,58 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block localectl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_unix_stream_socket)
+
+	   (call systemd.logparsenv.type (subj))
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.locale.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .kbd.data.list_file_dirs (subj))
+	   (call .kbd.data.read_file_files (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdlocalectl_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdlocalectl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/localectl" file file_context))))

--- a/src/agent/misc/systemd/systemdloginctl.cil
+++ b/src/agent/misc/systemd/systemdloginctl.cil
@@ -1,0 +1,72 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block loginctl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.journal.log.map_file_pattern.type (subj))
+	   (call systemd.journal.log.read_file_pattern.type (subj))
+
+	   (call systemd.login.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .bus.search_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dev.traverse_sysfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_files (subj))
+	   (call .devices.traverse_sysfile_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .nss.passwdgroup.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.read_subj_states (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.status_system (subj))
+
+	   (call .tmp.getattr_fs_pattern.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdloginctl_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdloginctl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/loginctl" file file_context))))

--- a/src/agent/misc/systemd/systemdmount.cil
+++ b/src/agent/misc/systemd/systemdmount.cil
@@ -1,0 +1,95 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block mount
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_unix_stream_socket)
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.pager.type (subj))
+	   (call systemd.private.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call systemd.unit.run.control_file_services (subj))
+
+	   (call .bus.list_sysfile_dirs (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.list_sysfile_dirs (subj))
+	   (call .class.read_sysfile_lnk_files (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_files (subj))
+	   (call .devices.traverse_sysfile_pattern.type (subj))
+
+	   (call .fsck.subj_type_transition (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .mount.image.getattr_all_files (subj))
+	   (call .mount.image.search_all_dirs (subj))
+	   (call .mount.mountpoint.search_all_dirs (subj))
+	   (call .mount.subj_type_transition (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .stordev.getattr_all_blk_files (subj))
+	   (call .stordev.getattr_all_chr_files (subj))
+
+	   (call .sys.read_subj_states (subj))
+	   (call .sys.reload_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
+	   (call .sys.start_system (subj))
+	   (call .sys.status_system (subj))
+	   (call .sys.stop_system (subj))
+
+	   (call .tmp.search_fs_dirs (subj))
+
+	   (call .user.run.search_file_pattern.type (subj))
+
+	   (call .zram.read_sysfile_files (subj))
+	   (call .zram.read_sysfile_lnk_files (subj))
+	   (call .zram.search_sysfile_dirs (subj))
+
+	   (optional systemdmount_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdmount_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (optional systemdmount_usersystemd
+		     (call .user.systemd.private.type (subj))
+		     (call .user.systemd.reload_system (subj))
+		     (call .user.systemd.start_system (subj))
+		     (call .user.systemd.status_system (subj))
+		     (call .user.systemd.stop_system (subj))
+		     (call .user.systemd.unit.run.control_file_services (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/systemd-mount" file file_context))))

--- a/src/agent/misc/systemd/systemdnetworkctl.cil
+++ b/src/agent/misc/systemd/systemdnetworkctl.cil
@@ -1,0 +1,81 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block networkctl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_netlink_generic_socket)
+	   (allow subj self create_netlink_route_socket)
+	   (allow subj self create_udp_socket)
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+	   (allow subj self (netlink_route_socket (nlmsg_read)))
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.conf.search_file_pattern.type (subj))
+
+	   (call systemd.journal.log.map_file_pattern.type (subj))
+	   (call systemd.journal.log.read_file_pattern.type (subj))
+
+	   (call systemd.netif.run.list_file_dirs (subj))
+	   (call systemd.netif.run.read_file_files (subj))
+
+	   (call systemd.network.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.udev.conf.map_file_files (subj))
+	   (call systemd.udev.conf.read_file_pattern.type (subj))
+	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call .bus.search_sysfile_pattern.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .devices.read_sysfile_files (subj))
+	   (call .devices.traverse_sysfile_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .machineid.read_file_files (subj))
+
+	   (call .net.read_procfile_pattern.type (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .random.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.read_subj_states (subj))
+
+	   (call .tmp.getattr_fs_pattern.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdnetworkctl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/networkctl" file file_context))))

--- a/src/agent/misc/systemd/systemdresolvectl.cil
+++ b/src/agent/misc/systemd/systemdresolvectl.cil
@@ -1,0 +1,50 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block resolvectl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_netlink_route_socket)
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self create_unix_stream_socket)
+	   (allow subj self (netlink_route_socket (nlmsg_read)))
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.network.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.resolve.sendmsg_subj_dbus.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .net.read_procfile_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.readstatesource.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .sys.read_subj_states (subj))
+
+	   (optional systemdresolvectl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/resolvectl" file file_context))))

--- a/src/agent/misc/systemd/systemdtimedatectl.cil
+++ b/src/agent/misc/systemd/systemdtimedatectl.cil
@@ -1,0 +1,54 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in systemd
+
+    (block timedatectl
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self create_unix_stream_socket)
+	   (dontaudit subj self (capability (net_admin)))
+
+	   (call systemd.pager.type (subj))
+
+	   (call systemd.askpassword.client.type (subj))
+
+	   (call systemd.machines.run.list_file_dirs (subj))
+	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.network.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.timedate.sendmsg_subj_dbus.type (subj))
+
+	   (call systemd.timesync.sendmsg_subj_dbus.type (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .machineid.read_file_files (subj))
+
+	   (call .ns.read_fs_pattern.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (optional systemdtimedatectl_opensshclient
+		     (call .openssh.client.subj_type_transition (subj)))
+
+	   (optional systemdtimedatectl_polkit
+		     (call .polkit.ttyagent.subj_type_transition (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/timedatectl" file file_context))))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -60,6 +60,9 @@
     (call .ci.manage_fs_pattern.type (subj))
     (call .ci.map_fs_files (subj))
 
+    ;; systemd-resolvectl bash-completion lists /sys/class/net
+    (call .class.list_sysfile_dirs (subj))
+
     (call .dos.getattr_fs_pattern.type (subj))
     (call .dos.manage_fs_pattern.type (subj))
     (call .dos.map_fs_files (subj))
@@ -92,6 +95,15 @@
 
     (call .systemd.askpassword.client.role (role))
 
+    (call .systemd.busctl.noatsecure_subj_processes (subj))
+    (call .systemd.busctl.role (role))
+
+    (call .systemd.cg.role (role))
+
+    (call .systemd.hostnamectl.role (role))
+
+    (call .systemd.inhibit.role (role))
+
     (call .systemd.journalctl.role (role))
     (call .systemd.journalctl.tmp.manage_file_dirs (subj))
     (call .systemd.journalctl.tmp.manage_file_files (subj))
@@ -99,10 +111,23 @@
     (call .systemd.journalctl.tmp.relabel_file_dirs (subj))
     (call .systemd.journalctl.tmp.relabel_file_files (subj))
 
+    (call .systemd.localectl.role (role))
+
+    (call .systemd.loginctl.role (role))
+
+    (call .systemd.mount.noatsecure_subj_processes (subj))
+    (call .systemd.mount.role (role))
+
+    (call .systemd.networkctl.role (role))
+
+    (call .systemd.resolvectl.role (role))
+
     (call .systemd.stdiobridge.role (role))
 
     (call .systemd.systemctl.noatsecure_subj_processes (subj))
     (call .systemd.systemctl.role (role))
+
+    (call .systemd.timedatectl.role (role))
 
     (call .tmp.deletename_file_dirs (subj))
     (call .tmp.deletename_fs_dirs (subj))

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -13,11 +13,31 @@
 
        (call .systemd.askpassword.client.role (role))
 
+       (call .systemd.busctl.role (role))
+
+       (call .systemd.cg.role (role))
+
+       (call .systemd.hostnamectl.role (role))
+
+       (call .systemd.inhibit.role (role))
+
        (call .systemd.journalctl.role (role))
+
+       (call .systemd.localectl.role (role))
+
+       (call .systemd.loginctl.role (role))
+
+       (call .systemd.mount.role (role))
+
+       (call .systemd.networkctl.role (role))
+
+       (call .systemd.resolvectl.role (role))
 
        (call .systemd.stdiobridge.role (role))
 
        (call .systemd.systemctl.role (role))
+
+       (call .systemd.timedatectl.role (role))
 
        (optional wheeluser_consolesetupcon
 		 (call .consolesetup.setupcon.role (role)))


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
- journalctl sets resource limits
- adds systemd analyze
- systemd analyze related
- systemd analyze
- various systemd utilities
