### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/systemd/systemdlocale.cil
+++ b/src/agent/misc/systemd/systemdlocale.cil
@@ -16,6 +16,9 @@
 	   (call systemd.notify.type (subj))
 	   (call systemd.pager.type (subj))
 
+	   (call systemd.data.read_file_files (subj))
+	   (call systemd.data.search_file_dirs (subj))
+
 	   (call systemd.journal.relay_msgs.type (subj))
 
 	   (call systemd.run.search_file_pattern.type (subj))
@@ -30,6 +33,8 @@
 
 	   (call .locale.conf.manage_file_files (subj))
 	   (call .locale.conf.conf_file_type_transition_file (subj))
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.data.read_file_pattern.type (subj))
 
 	   (call .osrelease.read_sysctlfile_pattern.type (subj))
 
@@ -46,6 +51,7 @@
 	   (call .selinux.mapread_fs_pattern.type (subj))
 
 	   (call .sys.reload_system (subj))
+	   (call .sys.sendmsg_subj_dbus.type (subj))
 	   (call .sys.start_system (subj))
 
 	   (call .x11.conf.conf_file_type_transition_file (subj))
@@ -53,6 +59,10 @@
 	   (call .x11.conf.manage_file_files (subj))
 
 	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional systemdlocale_consolesetup
+		     (call .consolesetup.conf.manage_file_files (subj))
+		     (call .consolesetup.conf.conf_file_type_transition (subj)))
 
 	   (optional systemdlocale_polkit
 		     (call .polkit.sendmsg_subj_dbus.type (subj)))

--- a/src/agent/misc/systemd/systemdlocalectl.cil
+++ b/src/agent/misc/systemd/systemdlocalectl.cil
@@ -17,10 +17,12 @@
 
 	   (call systemd.locale.sendmsg_subj_dbus.type (subj))
 
-	   (call systemd.run.search_file_pattern.type (subj))
-
 	   (call systemd.machines.run.list_file_dirs (subj))
 	   (call systemd.machines.run.read_file_files (subj))
+
+	   (call systemd.run.search_file_pattern.type (subj))
+
+	   (call systemd.unit.run.search_file_dirs (subj))
 
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/misc/systemd/systemdlogin.cil
+++ b/src/agent/misc/systemd/systemdlogin.cil
@@ -46,9 +46,9 @@
     (call systemd.inhibit.run.manage_file_fifo_files (subj))
     (call systemd.inhibit.run.readwrite_file_dirs (subj))
 
-    (call .systemd.journal.relay_msgs.type (subj))
-;; TODO
-;;    (call systemd.loginctl.read_subj_states (subj))
+    (call systemd.journal.relay_msgs.type (subj))
+
+    (call systemd.loginctl.read_subj_states (subj))
 
     (call systemd.network.sendmsg_subj_dbus.type (subj))
 

--- a/src/agent/sysagent/c/consolesetup.cil
+++ b/src/agent/sysagent/c/consolesetup.cil
@@ -40,13 +40,19 @@
 	      (filecon "/etc/default/keyboard" file file_context)
 	      (filecon "/etc/default/keyboard\..*" file file_context)
 
+	      ;; makes systemd-localed happy
+	      (filecon "/etc/vconsole\.conf" file file_context)
+	      (filecon "/etc/vconsole\.conf\..*" file file_context)
+
 	      (macro conf_file_type_transition_file ((type ARG1))
 		     (call .conf.file_type_transition
 			   (ARG1 file dir "console-setup"))
 		     (call .conf.file_type_transition
 			   (ARG1 file file "console-setup"))
 		     (call .conf.file_type_transition
-			   (ARG1 file file "keyboard")))
+			   (ARG1 file file "keyboard"))
+		     (call .conf.file_type_transition
+			   (ARG1 file file "vconsole.conf")))
 
 	      (blockinherit .file.conf.template))
 


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
- journalctl sets resource limits
- adds systemd analyze
- systemd analyze related
- systemd analyze
- various systemd utilities
- systemd localed hacks to make it work with consolesetup
