### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/dbus/dbusdaemon.cil
+++ b/src/agent/misc/dbus/dbusdaemon.cil
@@ -57,9 +57,18 @@
 
 	  (call systemd.analyze.sendmsg_subj_dbus.type (systemd.hostname.subj)))
 
+(optional systemdhostname_systemdhostnamectl
+
+	  (call systemd.hostnamectl.sendmsg_subj_dbus.type
+		(systemd.hostname.subj)))
+
 (optional systemdlogin_login
 
 	  (call login.sendmsg_subj_dbus.type (systemd.login.subj)))
+
+(optional systemdlogin_systemdloginctl
+
+	  (call systemd.loginctl.sendmsg_subj_dbus.type (systemd.login.subj)))
 
 (optional systemdlogin_opensshserver
 
@@ -74,3 +83,13 @@
 
 	  (call systemd.nspawn.sendmsg_subj_dbus.type
 		(systemd.machine.subj)))
+
+(optional systemdtimedate_systemdtimedatectl
+
+	  (call systemd.timedatectl.sendmsg_subj_dbus.type
+		(systemd.timedate.subj)))
+
+(optional systemdtimesync_systemdtimedatectl
+
+	  (call systemd.timedatectl.sendmsg_subj_dbus.type
+		(systemd.timesync.subj)))

--- a/src/agent/misc/systemd.cil
+++ b/src/agent/misc/systemd.cil
@@ -1433,6 +1433,9 @@
 		     (filecon "/run/systemd/transient" dir file_context)
 		     (filecon "/run/systemd/transient/.*" any file_context)
 
+		     (macro getattr_file_dirs ((type ARG1))
+			    (allow ARG1 file (dir (getattr))))
+
 		     (macro systemd_run_file_type_transition_file
 			    ((type ARG1)(class ARG2)(name ARG3))
 			    (call .systemd.run.file_type_transition

--- a/src/agent/misc/systemd/systemdhostnamectl.cil
+++ b/src/agent/misc/systemd/systemdhostnamectl.cil
@@ -18,7 +18,7 @@
 	   (call systemd.machines.run.list_file_dirs (subj))
 	   (call systemd.machines.run.read_file_files (subj))
 
-	   (call systemd.run.search_file_pattern.type (subj))
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/misc/systemd/systemdlocalectl.cil
+++ b/src/agent/misc/systemd/systemdlocalectl.cil
@@ -20,9 +20,7 @@
 	   (call systemd.machines.run.list_file_dirs (subj))
 	   (call systemd.machines.run.read_file_files (subj))
 
-	   (call systemd.run.search_file_pattern.type (subj))
-
-	   (call systemd.unit.run.search_file_dirs (subj))
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/misc/systemd/systemdlogin.cil
+++ b/src/agent/misc/systemd/systemdlogin.cil
@@ -76,6 +76,8 @@
     (call users.run.manage_file_files (subj))
     (call users.run.readwrite_file_dirs (subj))
 
+    (call .block.traverse_sysfile_pattern.type (subj))
+
     (call .bus.list_sysfile_dirs (subj))
     (call .bus.read_sysfile_lnk_files (subj))
 
@@ -96,8 +98,9 @@
 
     (call .dev.traverse_sysfile_pattern.type (subj))
 
+    (call .devices.list_sysfile_dirs (subj))
+    (call .devices.read_sysfile_lnk_files (subj))
     (call .devices.readwrite_sysfile_files (subj))
-    (call .devices.traverse_sysfile_pattern.type (subj))
 
     (call .devpts.search_fs_pattern.type (subj))
 
@@ -105,6 +108,9 @@
 
     (call .dri.readwrite_nodedev_pattern.type (subj))
     (call .dri.setattr_nodedev_chr_files (subj))
+
+    (call .efivar.read_fs_files (subj))
+    (call .efivar.search_fs_pattern.type (subj))
 
     (call .event.readwrite_nodedev_chr_files (subj))
     (call .event.setattr_nodedev_chr_files (subj))

--- a/src/agent/misc/systemd/systemdloginctl.cil
+++ b/src/agent/misc/systemd/systemdloginctl.cil
@@ -8,6 +8,8 @@
 	   (blockinherit .dbus.client.template)
 	   (blockinherit .hybrid.agent.template)
 
+	   (allow subj self (process (setrlimit)))
+
 	   (call systemd.pager.type (subj))
 
 	   (call systemd.askpassword.client.type (subj))
@@ -21,6 +23,8 @@
 	   (call systemd.machines.run.read_file_files (subj))
 
 	   (call systemd.udev.run.read_file_pattern.type (subj))
+
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .bus.search_sysfile_pattern.type (subj))
 

--- a/src/agent/misc/systemd/systemdtimedatectl.cil
+++ b/src/agent/misc/systemd/systemdtimedatectl.cil
@@ -20,13 +20,15 @@
 
 	   (call systemd.network.sendmsg_subj_dbus.type (subj))
 
-	   (call systemd.run.search_file_pattern.type (subj))
-
 	   (call systemd.timedate.sendmsg_subj_dbus.type (subj))
 
 	   (call systemd.timesync.sendmsg_subj_dbus.type (subj))
 
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
+
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .cgroup.getattr_fs_pattern.type (subj))
 
 	   (call .crypto.read_sysctlfile_pattern.type (subj))
 
@@ -42,6 +44,8 @@
 	   (call .rbacsep.constrained.type (subj))
 
 	   (call .selinux.linked.type (subj))
+
+	   (call .sys.read_subj_states (subj))
 
 	   (optional systemdtimedatectl_opensshclient
 		     (call .openssh.client.subj_type_transition (subj)))

--- a/src/agent/misc/systemd/systemdudev.cil
+++ b/src/agent/misc/systemd/systemdudev.cil
@@ -68,7 +68,7 @@
 
 	   (call systemd.systemctl.exec.execute_file_files (subj))
 
-	   (call systemd.unit.run.search_file_dirs (subj))
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .apparmor.readwrite_sysfile_files (subj))
 	   (call .apparmor.search_sysfile_dirs (subj))

--- a/src/agent/misc/systemd/usersystemd.cil
+++ b/src/agent/misc/systemd/usersystemd.cil
@@ -411,7 +411,7 @@
 
 	   (call .systemd.udev.run.read_file_pattern.type (subj))
 
-	   (call .systemd.unit.run.search_file_dirs (subj))
+	   (call .systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .threadsmax.read_sysctlfile_files (subj))
 

--- a/src/agent/misc/systemd/usersystemdrun.cil
+++ b/src/agent/misc/systemd/usersystemdrun.cil
@@ -75,7 +75,7 @@
     (call .systemd.run.exec.mapexecute_file_files (subj))
     (call .systemd.run.exec.read_file_files (subj))
 
-    (call .systemd.run.search_file_dirs (subj))
+    (call .systemd.unit.run.getattr_dir_pattern.type (subj))
 
     (call .user.agent.exec.auditexecuteaccess_all_files (subj))
     (call .user.agent.type (subj))

--- a/src/agent/misc/systemdcontainer/systemdmachinectl.cil
+++ b/src/agent/misc/systemdcontainer/systemdmachinectl.cil
@@ -41,9 +41,7 @@
 	   (call systemd.nspawn.container.unit.start_all_services (subj))
 	   (call systemd.nspawn.container.unit.status_all_services (subj))
 
-	   (call systemd.run.search_file_pattern.type (subj))
-
-	   (call systemd.unit.run.search_file_dirs (subj))
+	   (call systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/misc/systemdcontainer/systemdnspawn.cil
+++ b/src/agent/misc/systemdcontainer/systemdnspawn.cil
@@ -13,31 +13,30 @@
 
     (call .systemd.nspawn.container.subj.role (role)))
 
-;; TODO
-;;(in systemd.analyze
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
 
-;; TODO
-;;(in systemd.busctl
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
+(in systemd.analyze
 
-;; TODO
-;;(in systemd.cg
-;;
-;;    (allow subj self (capability (sys_admin)))
-;;
-;;    (call systemd.nspawn.container.subj.read_all_states (subj))
-;;    (call systemd.nspawn.container.unit.status_all_services (subj)))
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
+
+
+(in systemd.busctl
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
+
+(in systemd.cg
+
+    (allow subj self (capability (sys_admin)))
+
+    (call systemd.nspawn.container.subj.read_all_states (subj))
+    (call systemd.nspawn.container.unit.status_all_services (subj)))
 
 (in systemd.import
 
@@ -51,39 +50,36 @@
     (call systemd.nspawn.container.obj.relabelto_all_files (subj))
     (call systemd.nspawn.container.obj.relabelto_all_lnk_files (subj)))
 
-;; TODO
-;;(in systemd.journalctl
-;;
-;;    (allow subj self
-;;	   (capability (dac_read_search setgid setuid sys_admin sys_chroot)))
-;;    (allow subj self (cap_userns (sys_admin sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.obj.getattr_all_fs (subj))
-;;
-;;    (call systemd.nspawn.container.obj.list_all_dirs (subj))
-;;    (call systemd.nspawn.container.obj.map_all_files (subj))
-;;    (call systemd.nspawn.container.obj.read_all_files (subj))
-;;    (call systemd.nspawn.container.obj.read_all_lnk_files (subj))
+(in systemd.journalctl
 
-;;    (call systemd.nspawn.container.subj.read_all_states (subj)))
+    (allow subj self
+	   (capability (dac_read_search setgid setuid sys_admin sys_chroot)))
+    (allow subj self (cap_userns (sys_admin sys_ptrace)))
 
-;; TODO
-;;(in systemd.localectl
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
+    (call systemd.nspawn.container.obj.getattr_all_fs (subj))
 
-;; TODO
-;;(in systemd.loginctl
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
+    (call systemd.nspawn.container.obj.list_all_dirs (subj))
+    (call systemd.nspawn.container.obj.map_all_files (subj))
+    (call systemd.nspawn.container.obj.read_all_files (subj))
+    (call systemd.nspawn.container.obj.read_all_lnk_files (subj))
+
+    (call systemd.nspawn.container.subj.read_all_states (subj)))
+
+(in systemd.localectl
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
+
+(in systemd.loginctl
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
 
 (in systemd.machinectl
 
@@ -94,14 +90,13 @@
     (call systemd.nspawn.container.client.type (subj))
     (call systemd.nspawn.container.obj.readwriteinherited_all_chr_files (subj)))
 
-;; TODO
-;;(in systemd.mount
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
+(in systemd.mount
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
 
 (in systemd.nspawn
 
@@ -908,11 +903,10 @@
 
     (call systemd.nspawn.container.client.type (subj)))
 
-;; TODO
-;;(in systemd.timedatectl
-;;
-;;    (allow subj self (capability (sys_admin sys_chroot)))
-;;    (allow subj self
-;;	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
-;;
-;;    (call systemd.nspawn.container.client.type (subj)))
+(in systemd.timedatectl
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))

--- a/src/agent/misc/utillinux/logger.cil
+++ b/src/agent/misc/utillinux/logger.cil
@@ -20,7 +20,7 @@
 
        (call .systemd.journal.relay_msgs.type (subj))
 
-       (call .systemd.unit.run.search_file_dirs (subj))
+       (call .systemd.unit.run.getattr_dir_pattern.type (subj))
 
        ;; grub runs os-prober which runs logger
        (optional logger_grub

--- a/src/agent/sysagent/d/dhclient.cil
+++ b/src/agent/sysagent/d/dhclient.cil
@@ -124,11 +124,9 @@
 	      (call .shell.exec.mapexecute_file_files (subj))
 	      (call .shell.exec.read_file_files (subj))
 
-	      (call .systemd.run.search_file_dirs (subj))
-
 	      (call .systemd.timesync.exec.auditexecuteaccess_file_files (subj))
 
-	      (call .systemd.unit.run.search_file_dirs (subj))
+	      (call .systemd.unit.run.getattr_dir_pattern.type (subj))
 
 	      (block exec
 

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -2412,6 +2412,19 @@
 
 	   (call .run.search_file_pattern.type (typeattr))))
 
+(in systemd.unit.run
+
+    (block getattr_dir_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call getattr_file_dirs (typeattr))
+
+	   (call .systemd.run.search_file_pattern.type (typeattr))))
+
 (in terminfo
 
     (block read_file_pattern


### PR DESCRIPTION
- e2fsprogs/systemddissect relocate
- systemd machine: some stuff surfaced with machinectl shell user@.host
- gnupg removes locks in user home
- systemd import lists certs
- deal with loopstordev labeling (its a special case)
- dbus-daemon adds method_return
- adds polkit
- deals with wide spread polkit method returns and dbus-daemon
- adds systemd journalctl
- journalctl sets resource limits
- adds systemd analyze
- systemd analyze related
- systemd analyze
- various systemd utilities
- systemd localed hacks to make it work with consolesetup
- lots of loose ends
