### PR TITLE
new

### DIFF
--- a/src/agent/misc/systemd/systemdnetworkctl.cil
+++ b/src/agent/misc/systemd/systemdnetworkctl.cil
@@ -32,8 +32,6 @@
 
 	   (call systemd.run.search_file_pattern.type (subj))
 
-	   (call systemd.udev.conf.map_file_files (subj))
-	   (call systemd.udev.conf.read_file_pattern.type (subj))
 	   (call systemd.udev.data.map_file_files (subj))
 	   (call systemd.udev.data.read_file_files (subj))
 	   (call systemd.udev.data.search_file_dirs (subj))


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
