### PR TITLE
new

### DIFF
--- a/src/agent/useragent/g/gh.cil
+++ b/src/agent/useragent/g/gh.cil
@@ -134,7 +134,9 @@
     (call .gh.home.data.relabel_file_files (subj))
     (call .gh.home.data.user_home_data_file_type_transition_file (subj))
     (call .gh.role (role))
+    (call .gh.tmp.manage_file_dirs (subj))
     (call .gh.tmp.manage_file_files (subj))
+    (call .gh.tmp.relabel_file_dirs (subj))
     (call .gh.tmp.relabel_file_files (subj))
     (call .gh.tmp.tmp_file_type_transition_file (subj dir "gh-cli-cache")))
 


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
