### PR TITLE
new

### DIFF
--- a/src/agent/hybridagent/c/consolesetupcon.cil
+++ b/src/agent/hybridagent/c/consolesetupcon.cil
@@ -84,6 +84,8 @@
 
 	   (call .var.traverse_file_pattern.type (subj))
 
+	   (call .user.home.search_file_pattern.type (subj))
+
 	   (optional consolesetupcon_initramfstools
 		     (call .initramfstools.tmp.manage_file_files (subj))
 		     (call .initramfstools.tmp.manage_file_dirs (subj))
@@ -129,6 +131,10 @@
 
     (call .consolesetup.setupcon.home.user_home_file_type_transition_file
 	  (typeattr)))
+
+(in kbd
+
+    (call .consolesetup.setupcon.tmp.read_file_files (subj)))
 
 (in null
 

--- a/src/agent/sysagent/i/initramfstools.cil
+++ b/src/agent/sysagent/i/initramfstools.cil
@@ -62,9 +62,14 @@
 
        (call .modules.read_procfile_pattern.type (subj))
 
+       ;; consolesetup copies /dev/null to /var/tmp/initramfs.*
+       (call .null.delete_nodedev_chr_files (subj))
+
        (call .perl5.data.read_file_files (subj))
 
        (call .pkgmgr.conf.read_file_files (subj))
+       (call .pkgmgr.state.manage_file_files (subj))
+       (call .pkgmgr.state.readwrite_file_dirs (subj))
 
        (call .random.read_nodedev_chr_files (subj))
 

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -42,6 +42,9 @@
        (optional wheeluser_consolesetupcon
 		 (call .consolesetup.setupcon.role (role)))
 
+       (optional wheeluser_kbd
+		 (call .kbd.role (role)))
+
        (optional wheeluser_mount
 		 (call .mount.role (role)))
 


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
