### PR TITLE
new

### DIFF
--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -147,6 +147,8 @@
 
        (call .meminfo.read_procfile_files (subj))
 
+       (call .mime.read_file_pattern.type (subj))
+
        (call .mpd.nameconnect_port_tcp_sockets (subj))
 
        (call .net.nodebind_netnode_tcp_sockets (subj))

--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -305,6 +305,8 @@
 
 	      (call .nss.passwdgroup.type (subj))
 
+	      (call .user.home.conf.search_file_pattern.type (subj))
+
 	      (call .user.run.search_file_pattern.type (subj))
 
 	      (call .user.systemd.agent (subj exec.file))

--- a/src/agent/useragent/u/usersandbox.cil
+++ b/src/agent/useragent/u/usersandbox.cil
@@ -92,7 +92,7 @@
 
 		  (call .meminfo.read_procfile_files (typeattr))
 
-		  (call .mime.data.read_file_pattern.type (typeattr))
+		  (call .mime.read_file_pattern.type (typeattr))
 
 		  (call .net.traverse_procfile_pattern.type (typeattr))
 
@@ -142,8 +142,7 @@
 
 		  (call .sysfile.dontaudit_listinherited_all_dirs (typeattr))
 
-		  (call .terminfo.conf.read_file_pattern.type (typeattr))
-		  (call .terminfo.data.read_file_pattern.type (typeattr))
+		  (call .terminfo.read_file_pattern.type (typeattr))
 
 		  (call .tty.read_procfile_files (typeattr))
 		  (call .tty.search_procfile_dirs (typeattr))

--- a/src/user.cil
+++ b/src/user.cil
@@ -111,7 +111,7 @@
 
 	   (call .meminfo.read_procfile_files (typeattr))
 
-	   (call .mime.data.read_file_pattern.type (typeattr))
+	   (call .mime.read_file_pattern.type (typeattr))
 
 	   (call .net.traverse_procfile_pattern.type (typeattr))
 
@@ -159,8 +159,7 @@
 
 	   (call .sysfile.dontaudit_listinherited_all_dirs (typeattr))
 
-	   (call .terminfo.conf.read_file_pattern.type (typeattr))
-	   (call .terminfo.data.read_file_pattern.type (typeattr))
+	   (call .terminfo.read_file_pattern.type (typeattr))
 
 	   (call .tty.read_procfile_files (typeattr))
 	   (call .tty.search_procfile_dirs (typeattr))


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
