### PR TITLE
new

### DIFF
--- a/src/agent/hybridagent/d/dictionaries.cil
+++ b/src/agent/hybridagent/d/dictionaries.cil
@@ -129,9 +129,7 @@
 	      (call .locale.data.map_file_pattern.type (subj))
 	      (call .locale.read_file_pattern.type (subj))
 
-	      (call .perl5.data.read_file_files (subj))
-	      (call .perl5.data.read_file_lnk_files (subj))
-	      (call .perl5.data.search_file_dirs (subj))
+	      (call .perl5.data.read_file_pattern.type (subj))
 
 	      (call .pkgmgr.state.manage_file_files (subj))
 	      (call .pkgmgr.state.readwrite_file_dirs (subj))

--- a/src/agent/misc/pam/pamauthupdate.cil
+++ b/src/agent/misc/pam/pamauthupdate.cil
@@ -23,9 +23,7 @@
        (call .pam.state.manage_file_files (subj))
        (call .pam.state.readwrite_file_dirs (subj))
 
-       (call .perl5.data.read_file_files (subj))
-       (call .perl5.data.read_file_lnk_files (subj))
-       (call .perl5.data.search_file_dirs (subj))
+       (call .perl5.data.read_file_pattern.type (subj))
 
        (call .pkgmgr.cache.manage_file_files (subj))
        (call .pkgmgr.cache.readwrite_file_dirs (subj))

--- a/src/agent/sysagent/i/initramfstools.cil
+++ b/src/agent/sysagent/i/initramfstools.cil
@@ -65,7 +65,7 @@
        ;; consolesetup copies /dev/null to /var/tmp/initramfs.*
        (call .null.delete_nodedev_chr_files (subj))
 
-       (call .perl5.data.read_file_files (subj))
+       (call .perl5.data.read_file_pattern.type (subj))
 
        (call .pkgmgr.conf.read_file_files (subj))
        (call .pkgmgr.state.manage_file_files (subj))

--- a/src/agent/useragent/g/gitemail.cil
+++ b/src/agent/useragent/g/gitemail.cil
@@ -50,8 +50,7 @@
 	   (call .nfs.getattr_fs_pattern.type (subj))
 	   (call .nfs.manage_fs_pattern.type (subj))
 
-	   (call .perl5.data.read_file_files (subj))
-	   (call .perl5.data.search_file_dirs (subj))
+	   (call .perl5.read_file_pattern.type (subj))
 
 	   (call .random.read_nodedev_chr_files (subj))
 

--- a/src/agent/useragent/r/reprepro.cil
+++ b/src/agent/useragent/r/reprepro.cil
@@ -1,0 +1,57 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block reprepro
+
+       (blockinherit .user.agent.template)
+
+       (allow subj self (process (getsched)))
+
+       (call .ci.getattr_fs_pattern.type (subj))
+       (call .ci.manage_fs_pattern.type (subj))
+       (call .ci.map_fs_files (subj))
+
+       (call .crypto.read_sysctlfile_pattern.type (subj))
+
+       (call .dos.getattr_fs_pattern.type (subj))
+       (call .dos.manage_fs_pattern.type (subj))
+       (call .dos.map_fs_files (subj))
+
+       (call .exec.execute_file_files (subj))
+
+       (call .fuse.getattr_fs_pattern.type (subj))
+       (call .fuse.manage_fs_pattern.type (subj))
+       (call .fuse.map_fs_files (subj))
+
+       (call .gnupg.subj_type_transition (subj))
+
+       (call .locale.data.map_file_pattern.type (subj))
+       (call .locale.read_file_pattern.type (subj))
+
+       (call .media.search_file_pattern.type (subj))
+
+       (call .media.home.traverse_file_pattern.type (subj))
+
+       (call .nfs.getattr_fs_pattern.type (subj))
+       (call .nfs.manage_fs_pattern.type (subj))
+       (call .nfs.map_fs_files (subj))
+
+       (call .tmp.search_file_dirs (subj))
+
+       (call .user.home.manage_file_dirs (subj))
+       (call .user.home.manage_file_files (subj))
+       (call .user.home.map_file_files (subj))
+
+       (block exec
+
+	      (filecon "/usr/bin/changestool" file file_context)
+	      (filecon "/usr/bin/reprepro" file file_context)
+	      (filecon "/usr/bin/rredtool" file file_context)))
+
+(in user
+
+    (call .reprepro.role (role)))
+
+(in wheel
+
+    (call .reprepro.role (role)))

--- a/src/agent/useragent/u/usersandbox.cil
+++ b/src/agent/useragent/u/usersandbox.cil
@@ -110,8 +110,7 @@
 		  (call .overcommitmemory.read_sysctlfile_pattern.type
 			(typeattr))
 
-		  (call .perl5.data.read_file_files (typeattr))
-		  (call .perl5.data.search_file_dirs (typeattr))
+		  (call .perl5.read_file_pattern.type (typeattr))
 
 		  (call .pidmax.read_sysctlfile_files (typeattr))
 

--- a/src/file/conffile/mimeconffile.cil
+++ b/src/file/conffile/mimeconffile.cil
@@ -9,10 +9,14 @@
 
     (block conf
 
+	   (filecon "/etc/mailcap" file file_context)
+	   (filecon "/etc/mailcap\..*" file file_context)
 	   (filecon "/etc/mime\.types" file file_context)
 	   (filecon "/etc/mime\.types\..*" file file_context)
 
 	   (macro conf_file_type_transition_file ((type ARG1))
+		  (call .conf.file_type_transition
+			(ARG1 file file "mailcap"))
 		  (call .conf.file_type_transition
 			(ARG1 file file "mime.types")))
 

--- a/src/file/conffile/perl5conffile.cil
+++ b/src/file/conffile/perl5conffile.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in perl5
+
+    (block conf
+
+	   (filecon "/etc/perl" dir file_context)
+	   (filecon "/etc/perl/.*" any file_context)
+
+	   (macro conf_file_type_transition_file ((type ARG1))
+		  (call .conf.file_type_transition
+			(ARG1 file dir "perl")))
+
+	   (blockinherit .file.conf.template)))
+
+(in file.unconfined
+
+    (call .perl5.conf.conf_file_type_transition_file (typeattr)))

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -1577,7 +1577,12 @@
 
 	   (typeattribute typeattr)
 
-	   (call data.read_file_pattern.type (typeattr))))
+	   (call conf.read_file_files (typeattr))
+	   (call data.read_file_pattern.type (typeattr))
+	   (call home.conf.read_file_pattern.type (typeattr))
+	   (call home.data.read_file_pattern.type (typeattr))
+
+	   (call .conf.search_file_pattern.type (typeattr))))
 
 (in mime.data
 
@@ -1655,16 +1660,6 @@
 	   (call read_file_files (typeattr))
 
 	   (call .user.home.data.search_file_pattern.type (typeattr))))
-
-(in mime.read_file_pattern
-
-    (call conf.read_file_files (typeattr))
-
-    (call home.conf.read_file_pattern.type (typeattr))
-
-    (call home.data.read_file_pattern.type (typeattr))
-
-    (call .conf.search_file_pattern.type (typeattr)))
 
 (in module
 
@@ -1895,6 +1890,48 @@
 	   (call read_sysctlfile_files (typeattr))
 
 	   (call .vm.search_sysctlfile_pattern.type (typeattr))))
+
+(in perl5
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call conf.read_file_pattern.type (typeattr))
+	   (call data.read_file_pattern.type (typeattr))))
+
+(in perl5.conf
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+	   (call read_file_lnk_files (typeattr))
+
+	   (call .conf.search_file_pattern.type (typeattr))))
+
+(in perl5.data
+
+    (block read_file_pattern
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (call list_file_dirs (typeattr))
+	   (call read_file_files (typeattr))
+	   (call read_file_lnk_files (typeattr))
+
+	   (call .data.search_file_pattern.type (typeattr))))
 
 (in p11kit.conf
 

--- a/src/user.cil
+++ b/src/user.cil
@@ -128,8 +128,7 @@
 
 	   (call .overcommitmemory.read_sysctlfile_pattern.type (typeattr))
 
-	   (call .perl5.data.read_file_files (typeattr))
-	   (call .perl5.data.search_file_dirs (typeattr))
+	   (call .perl5.read_file_pattern.type (typeattr))
 
 	   (call .pidmax.read_sysctlfile_files (typeattr))
 


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
