### PR TITLE
new

### DIFF
--- a/src/agent/hybridagent/c/consolesetupcon.cil
+++ b/src/agent/hybridagent/c/consolesetupcon.cil
@@ -56,8 +56,6 @@
 
 	   (call .rbac.objchangesys.type (subj))
 
-	   (call .rbacsep.constrained.type (subj))
-
 	   (call .root.list_file_dirs (subj))
 
 	   (call .shell.exec.execute_file_files (subj))

--- a/src/agent/hybridagent/d/dictionaries.cil
+++ b/src/agent/hybridagent/d/dictionaries.cil
@@ -129,7 +129,7 @@
 	      (call .locale.data.map_file_pattern.type (subj))
 	      (call .locale.read_file_pattern.type (subj))
 
-	      (call .perl5.data.read_file_pattern.type (subj))
+	      (call .perl5.read_file_pattern.type (subj))
 
 	      (call .pkgmgr.state.manage_file_files (subj))
 	      (call .pkgmgr.state.readwrite_file_dirs (subj))
@@ -140,6 +140,8 @@
 	      (call .rbacsep.usefdsource.type (subj))
 
 	      (call .shell.exec.execute_file_files (subj))
+
+	      (call .state.search_file_pattern.type (subj))
 
 	      (call .tmp.deletename_file_dirs (subj))
 

--- a/src/agent/misc/pam/pamauthupdate.cil
+++ b/src/agent/misc/pam/pamauthupdate.cil
@@ -5,6 +5,8 @@
 
        (blockinherit .sys.agent.template)
 
+       (call exec.execute_file_files (subj))
+
        (call .cache.search_file_pattern.type (subj))
 
        (call .exec.execute_file_files (subj))
@@ -23,7 +25,7 @@
        (call .pam.state.manage_file_files (subj))
        (call .pam.state.readwrite_file_dirs (subj))
 
-       (call .perl5.data.read_file_pattern.type (subj))
+       (call .perl5.read_file_pattern.type (subj))
 
        (call .pkgmgr.cache.manage_file_files (subj))
        (call .pkgmgr.cache.readwrite_file_dirs (subj))

--- a/src/agent/misc/systemd/systemdhwdb.cil
+++ b/src/agent/misc/systemd/systemdhwdb.cil
@@ -16,14 +16,10 @@
 
 	   (call systemd.journal.relay_msgs.type (subj))
 
-	   (call systemd.udev.conf.conf_file_type_transition_file (subj))
-	   (call systemd.udev.conf.manage_file_dirs (subj))
-	   (call systemd.udev.conf.manage_file_files (subj))
-	   (call systemd.udev.conf.map_file_files (subj))
-	   (call systemd.udev.conf.relabel_file_files (subj))
 	   (call systemd.udev.data.lib_file_type_transition_file (subj))
 	   (call systemd.udev.data.manage_file_dirs (subj))
 	   (call systemd.udev.data.manage_file_files (subj))
+	   (call systemd.udev.data.relabel_file_files (subj))
 
 	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
 


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
- hwdb is in /usr/lib/udev and setupcon can't be rbacsep constrained
