### PR TITLE
new

### DIFF
--- a/src/agent/sysagent/d/dosfstools.cil
+++ b/src/agent/sysagent/d/dosfstools.cil
@@ -15,6 +15,7 @@
        (call .stordev.readwrite_all_blk_files (subj))
        (call .stordev.readwrite_all_chr_files (subj))
 
+       (call .systemd.fsck.readwrite_subj_unix_stream_sockets (subj))
        (call .systemd.fsck.writeinherited_subj_fifo_files (subj))
        (call .systemd.fsck.use_subj_fds (subj))
 

--- a/src/agent/useragent/p/pipewire.cil
+++ b/src/agent/useragent/p/pipewire.cil
@@ -1,0 +1,191 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block pipewire
+
+       (macro unix_stream_connect ((type ARG1))
+	      (call connectto_subj_unix_stream_sockets (ARG1))
+	      (call run.write_file_sock_files (ARG1)))
+
+       (blockinherit .dbus.client.macro_template)
+       (blockinherit .user.agent.template)
+
+       (allow subj self (unix_stream_socket (accept listen)))
+
+       (call common.type (subj))
+
+       (call run.manage_file_files (subj))
+       (call run.manage_file_sock_files (subj))
+       (call run.user_run_file_type_transition_file (subj))
+
+       (call tmpfs.manage_file_files (subj))
+       (call tmpfs.map_file_files (subj))
+       (call tmpfs.tmp_fs_type_transition_file (subj))
+
+       (call .class.traverse_sysfile_pattern.type (subj))
+
+       (call .crypto.read_sysctlfile_pattern.type (subj))
+
+       (call .dbus.client.type (subj))
+
+       (call .snd.map_nodedev_chr_files (subj))
+       (call .snd.readwrite_nodedev_chr_files (subj))
+
+       (call .sys.modulerequest_subj_system (subj))
+
+       (call .user.dbus.client.type (subj))
+
+       (call .user.run.deletename_file_dirs (subj))
+
+       (call .user.systemd.agent (subj exec.file))
+       (call .user.systemd.service.nnptransition.type (subj))
+       (call .user.systemd.socketactivated.unixstream.type (subj))
+
+       (call .v4l.readwrite_nodedev_chr_files (subj))
+
+       (block common
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (typeattribute typeattr)
+
+	      (allow typeattr self (process (getsched setrlimit setsched)))
+	      (allow typeattr self create_unix_dgram_socket)
+
+	      (call data.list_file_dirs (typeattr))
+	      (call data.map_file_files (typeattr))
+	      (call data.read_file_files (typeattr))
+
+	      (call .alsa.data.read_file_files (typeattr))
+	      (call .alsa.data.search_file_dirs (typeattr))
+
+	      (call .devices.read_sysfile_files (typeattr))
+	      (call .devices.traverse_sysfile_pattern.type (typeattr))
+
+	      (call .locale.data.map_file_pattern.type (typeattr))
+	      (call .locale.read_file_pattern.type (typeattr))
+
+	      (call .nss.passwdgroup.type (typeattr))
+
+	      (call .selinux.linked.type (typeattr))
+
+	      (call .systemd.journal.relay_msgs.type (typeattr)))
+
+       (block data
+
+	      (filecon "/usr/share/pipewire" dir file_context)
+	      (filecon "/usr/share/pipewire/.*" any file_context)
+
+	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "pipewire")))
+
+	      (macro map_file_files ((type ARG1))
+		     (allow ARG1 file (file (map))))
+
+	      (blockinherit .file.data.base_template)
+	      (blockinherit .file.macro_template_dirs)
+	      (blockinherit .file.macro_template_files))
+
+       (block exec
+
+	      (filecon "/usr/bin/pipewire" file file_context))
+
+       (block run
+
+	      (filecon "/run/user/%{USERID}/pipewire-([0-9]+)?" socket
+		       file_context)
+	      (filecon "/run/user/%{USERID}/pipewire-([0-9]+)?\.lock" file
+		       file_context)
+
+	      (macro user_run_file_type_transition_file ((type ARG1))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "pipewire-0.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "pipewire-1.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "pipewire-2.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "pipewire-3.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "pipewire-0"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "pipewire-1"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "pipewire-2"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "pipewire-3")))
+
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.macro_template_sock_files)
+	      (blockinherit .file.user.run.base_template)
+
+	      (call .user.systemd.socketactivated.type (file)))
+
+       (block tmpfs
+
+	      (macro map_file_files ((type ARG1))
+		     (allow ARG1 file (file (map))))
+
+	      (macro tmp_fs_type_transition_file ((type ARG1))
+		     (call .tmp.fs_type_transition
+			   (ARG1 file file "*")))
+
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.user.tmpfs.base_template))
+
+       (block unit
+
+	      (filecon "/usr/lib/systemd/user/pipewire\.service.*" file
+		       file_context)
+	      (filecon "/usr/lib/systemd/user/pipewire\.socket.*" file
+		       file_context)
+
+	      (blockinherit .file.user.unit.template))
+
+       (block util
+
+	      (blockinherit .user.agent.template)
+
+	      (block exec
+
+		     (filecon "/usr/bin/pw-cat" file file_context)
+		     (filecon "/usr/bin/pw-cli" file file_context)
+		     (filecon "/usr/bin/pw-dot" file file_context)
+		     (filecon "/usr/bin/pw-dump" file file_context)
+		     (filecon "/usr/bin/pw-link" file file_context)
+		     (filecon "/usr/bin/pw-loopback" file file_context)
+		     (filecon "/usr/bin/pw-metadata" file file_context)
+		     (filecon "/usr/bin/pw-mididump" file file_context)
+		     (filecon "/usr/bin/pw-mon" file file_context)
+		     (filecon "/usr/bin/pw-profiler" file file_context)
+		     (filecon "/usr/bin/pw-reserve" file file_context)
+		     (filecon "/usr/bin/pw-top" file file_context)
+		     (filecon "/usr/bin/spa-acp-tool" file file_context)
+		     (filecon "/usr/bin/spa-inspect" file file_context)
+		     (filecon "/usr/bin/spa-json-dump" file file_context)
+		     (filecon "/usr/bin/spa-monitor" file file_context)
+		     (filecon "/usr/bin/spa-resample" file file_context))))
+
+(in file.unconfined
+
+    (call .pipewire.data.data_file_type_transition_file (typeattr))
+    (call .pipewire.run.user_run_file_type_transition_file (typeattr)))
+
+(in user
+
+    (call .pipewire.role (role))
+    (call .pipewire.run.manage_file_files (subj))
+    (call .pipewire.run.manage_file_sock_files (subj))
+    (call .pipewire.run.relabel_file_files (subj))
+    (call .pipewire.run.relabel_file_sock_files (subj))
+    (call .pipewire.run.user_run_file_type_transition_file (subj))
+    (call .pipewire.tmpfs.manage_file_files (subj))
+    (call .pipewire.tmpfs.relabel_file_files (subj))
+    (call .pipewire.util.role (role)))
+
+(in wheel
+
+    (call .pipewire.role (role))
+    (call .pipewire.util.role (role)))

--- a/src/agent/useragent/p/pipewirepulse.cil
+++ b/src/agent/useragent/p/pipewirepulse.cil
@@ -1,0 +1,187 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in pipewire
+
+    (call pulse.read_subj_states (subj))
+
+    (block pulse
+
+	   (macro unix_stream_connect ((type ARG1))
+		  (call connectto_subj_unix_stream_sockets (ARG1))
+		  (call run.search_file_dirs (ARG1))
+		  (call run.write_file_sock_files (ARG1)))
+
+	   (blockinherit .dbus.client.macro_template)
+	   (blockinherit .user.agent.template)
+
+	   (allow subj self (unix_stream_socket (accept listen)))
+
+	   (call client.read_all_states (subj))
+
+	   (call common.type (subj))
+
+	   (call pipewire.tmpfs.map_file_files (subj))
+	   (call pipewire.tmpfs.readwriteinherited_file_files (subj))
+
+	   (call pipewire.unix_stream_connect (subj))
+	   (call pipewire.use_subj_fds (subj))
+
+	   (call run.manage_file_dirs (subj))
+	   (call run.manage_file_files (subj))
+	   (call run.manage_file_sock_files (subj))
+	   (call run.user_run_file_type_transition_file (subj))
+
+	   (call tmpfs.manage_file_files (subj))
+	   (call tmpfs.map_file_files (subj))
+	   (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	   (call .class.traverse_sysfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dbus.client.type (subj))
+
+	   (call .tmp.deletename_fs_dirs (subj))
+
+	   (call .user.dbus.nameclient.type (subj))
+
+	   (call .user.run.deletename_file_dirs (subj))
+
+	   (call .user.systemd.agent (subj exec.file))
+	   (call .user.systemd.service.nnptransition.type (subj))
+	   (call .user.systemd.socketactivated.unixstream.type (subj))
+
+	   (block conf
+
+		  (filecon "/etc/pulse" dir file_context)
+		  (filecon "/etc/pulse/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "pulse")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block client
+
+		  (macro read_all_states ((type ARG1))
+			 (allow ARG1 typeattr (state (read))))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (typeattribute typeattr)
+
+		  (call connectto_subj_unix_stream_sockets (typeattr))
+
+		  (call conf.list_file_dirs (typeattr))
+		  (call conf.read_file_files (typeattr))
+
+		  (call home.conf.manage_file_dirs (typeattr))
+		  (call home.conf.manage_file_files (typeattr))
+		  (call home.conf.user_home_conf_file_type_transition_file
+			(typeattr))
+
+		  (call run.list_file_dirs (typeattr))
+		  (call run.setattr_file_dirs (typeattr))
+		  (call run.write_file_sock_files (typeattr))
+
+		  (call .tmp.deletename_fs_dirs (typeattr))
+
+		  (call .user.home.conf.create_file_dir_pattern.type (typeattr))
+
+		  (call .user.run.search_file_pattern.type (typeattr)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/pipewire-pulse" file file_context))
+
+	   (block home
+
+		  (block conf
+
+			 (filecon "HOME_DIR/\.config/pulse" dir file_context)
+			 (filecon "HOME_DIR/\.config/pulse/.*" any
+				  file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_conf_file_type_transition_file
+				((type ARG1))
+				(call .user.home.conf.file_type_transition
+				      (ARG1 file dir "pulse")))
+
+			 (blockinherit .file.user.home.conf.template)))
+
+	   (block run
+
+		  (filecon "/run/user/%{USERID}/pulse" dir file_context)
+		  (filecon "/run/user/%{USERID}/pulse/.*" any file_context)
+
+		  (macro setattr_file_dirs ((type ARG1))
+			 (allow ARG1 file (dir (setattr))))
+
+		  (macro user_run_file_type_transition_file ((type ARG1))
+			 (call .user.run.file_type_transition
+			       (ARG1 file dir "pulse")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.macro_template_sock_files)
+		  (blockinherit .file.user.run.base_template)
+
+		  (call .user.systemd.socketactivated.type (file)))
+
+	   (block tmpfs
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro tmp_fs_type_transition_file ((type ARG1))
+			 (call .tmp.fs_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.user.tmpfs.base_template))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/user/pipewire-pulse\.service.*"
+			   file file_context)
+		  (filecon "/usr/lib/systemd/user/pipewire-pulse\.socket.*"
+			   file file_context)
+
+		  (blockinherit .file.user.unit.template))))
+
+(in file.unconfined
+
+    (call .pipewire.pulse.conf.conf_file_type_transition_file (typeattr))
+    (call .pipewire.pulse.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr))
+    (call .pipewire.pulse.run.user_run_file_type_transition_file (typeattr)))
+
+(in user
+
+    (call .pipewire.pulse.home.conf.manage_file_dirs (subj))
+    (call .pipewire.pulse.home.conf.manage_file_files (subj))
+    (call .pipewire.pulse.home.conf.map_file_files (subj))
+    (call .pipewire.pulse.home.conf.relabel_file_dirs (subj))
+    (call .pipewire.pulse.home.conf.relabel_file_files (subj))
+    (call .pipewire.pulse.home.conf.user_home_conf_file_type_transition_file
+	  (subj))
+    (call .pipewire.pulse.role (role))
+    (call .pipewire.pulse.run.manage_file_dirs (subj))
+    (call .pipewire.pulse.run.manage_file_files (subj))
+    (call .pipewire.pulse.run.manage_file_sock_files (subj))
+    (call .pipewire.pulse.run.relabel_file_dirs (subj))
+    (call .pipewire.pulse.run.relabel_file_files (subj))
+    (call .pipewire.pulse.run.relabel_file_sock_files (subj))
+    (call .pipewire.pulse.run.user_run_file_type_transition_file (subj))
+    (call .pipewire.pulse.tmpfs.manage_file_files (subj))
+    (call .pipewire.pulse.tmpfs.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .pipewire.pulse.role (role)))

--- a/src/agent/useragent/w/wireplumber.cil
+++ b/src/agent/useragent/w/wireplumber.cil
@@ -1,0 +1,158 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block wireplumber
+
+       (blockinherit .dbus.client.macro_template)
+       (blockinherit .user.agent.template)
+
+       (allow subj self create_bluetooth_socket)
+       (allow subj self create_netlink_kobject_uevent_socket)
+       (allow subj self (bluetooth_socket (listen)))
+
+       (call data.read_file_files (subj))
+       (call data.search_file_dirs (subj))
+
+       (call home.conf.manage_file_dirs (subj))
+       (call home.conf.manage_file_files (subj))
+       (call home.conf.user_home_conf_file_type_transition_file (subj))
+
+       (call .bus.list_sysfile_pattern.type (subj))
+       (call .bus.read_sysfile_lnk_files (subj))
+
+       (call .class.list_sysfile_pattern.type (subj))
+       (call .class.read_sysfile_lnk_files (subj))
+
+       (call .crypto.read_sysctlfile_pattern.type (subj))
+
+       (call .dbus.client.type (subj))
+
+       (call .dev.list_file_pattern.type (subj))
+       (call .dev.watch_file_dirs (subj))
+
+       (call .pipewire.common.type (subj))
+       (call .pipewire.unix_stream_connect (subj))
+
+       (call .snd.map_nodedev_chr_files (subj))
+       (call .snd.readwrite_nodedev_chr_files (subj))
+
+       (call .state.search_file_pattern.type (subj))
+
+       (call .systemd.udev.run.read_file_pattern.type (subj))
+
+       (call .user.home.conf.create_file_dir_pattern.type (subj))
+
+       (call .user.dbus.nameclient.type (subj))
+
+       (call .user.run.search_file_pattern.type (subj))
+
+       (call .user.systemd.agent (subj exec.file))
+       (call .user.systemd.service.nnptransition.type (subj))
+
+       (call .v4l.readwrite_nodedev_chr_files (subj))
+
+       (call .xattr.getattr_fs_pattern.type (subj))
+
+       (optional wireplumber_bluez
+		 (call .bluez.sendmsg_subj_dbus.type (subj)))
+
+       (block data
+
+	      (filecon "/usr/share/wireplumber" dir file_context)
+	      (filecon "/usr/share/wireplumber/.*" any file_context)
+
+	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "wireplumber")))
+
+	      (blockinherit .file.data.template))
+
+       (block exec
+
+	      (filecon "/usr/bin/wireplumber" file file_context))
+
+       (block home
+
+	      (block conf
+
+		     (filecon "HOME_DIR/\.config/wireplumber" dir file_context)
+		     (filecon "HOME_DIR/\.config/wireplumber/.*" any
+			      file_context)
+
+		     (macro user_home_conf_file_type_transition_file
+			    ((type ARG1))
+			    (call .user.home.conf.file_type_transition
+				  (ARG1 file dir "wireplumber")))
+
+		     (blockinherit .file.macro_template_dirs)
+		     (blockinherit .file.macro_template_files)
+		     (blockinherit .file.user.home.conf.base_template)))
+
+       (block unit
+
+	      (filecon "/usr/lib/systemd/user/wireplumber\.service.*" file
+		       file_context)
+	      (filecon "/usr/lib/systemd/user/wireplumber@.*\.service.*" file
+		       file_context)
+
+	      (blockinherit .file.user.unit.template))
+
+       (block util
+
+	      (blockinherit .user.agent.template)
+
+	      (allow subj self (process (getsched setsched)))
+
+	      (call home.conf.read_file_files (subj))
+	      (call home.conf.search_file_dirs (subj))
+
+	      (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	      (call .locale.data.map_file_pattern.type (subj))
+	      (call .locale.read_file_pattern.type (subj))
+
+	      (call .nss.passwdgroup.type (subj))
+
+	      (call .pipewire.data.map_file_files (subj))
+	      (call .pipewire.data.read_file_files (subj))
+	      (call .pipewire.data.search_file_dirs (subj))
+
+	      (call .pipewire.unix_stream_connect (subj))
+
+	      (call .selinux.linked.type (subj))
+
+	      (call .user.home.conf.search_file_pattern.type (subj))
+
+	      (call .user.run.search_file_pattern.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/wpctl" file file_context)
+		     (filecon "/usr/bin/wpexec" file file_context))))
+
+(in file.unconfined
+
+    (call .wireplumber.data.data_file_type_transition_file (typeattr))
+    (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr)))
+
+(in pipewire
+
+    (call .wireplumber.read_subj_states (subj))
+    (call .wireplumber.util.read_subj_states (subj)))
+
+(in user
+
+    (call .wireplumber.home.conf.manage_file_dirs (subj))
+    (call .wireplumber.home.conf.manage_file_files (subj))
+    (call .wireplumber.home.conf.relabel_file_dirs (subj))
+    (call .wireplumber.home.conf.relabel_file_files (subj))
+    (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
+	  (subj))
+    (call .wireplumber.role (role))
+    (call .wireplumber.util.role (role)))
+
+(in wheel
+
+    (call .wireplumber.role (role))
+    (call .wireplumber.util.role (role)))

--- a/src/dev/nodedev/sndnodedev.cil
+++ b/src/dev/nodedev/sndnodedev.cil
@@ -8,6 +8,9 @@
        (macro getattr_nodedev_chr_files ((type ARG1))
 	      (allow ARG1 nodedev (chr_file (getattr))))
 
+       (macro map_nodedev_chr_files ((type ARG1))
+	      (allow ARG1 nodedev (chr_file (map))))
+
        (macro setattr_nodedev_chr_files ((type ARG1))
 	      (allow ARG1 nodedev (chr_file (setattr))))
 

--- a/src/file/datafile/alsadatafile.cil
+++ b/src/file/datafile/alsadatafile.cil
@@ -8,9 +8,14 @@
 	      (filecon "/usr/share/alsa" dir file_context)
 	      (filecon "/usr/share/alsa/.*" any file_context)
 
+	      (filecon "/usr/share/alsa-card-profile" dir file_context)
+	      (filecon "/usr/share/alsa-card-profile/.*" any file_context)
+
 	      (macro data_file_type_transition_file ((type ARG1))
 		     (call .data.file_type_transition
-			   (ARG1 file dir "alsa")))
+			   (ARG1 file dir "alsa"))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "alsa-card-profile")))
 
 	      (blockinherit .file.data.base_template)
 	      (blockinherit .file.macro_template_dirs)


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
- hwdb is in /usr/lib/udev and setupcon can't be rbacsep constrained
- dosfstools systemd-fsck: might be a leak
- adds pipewire and wireplumber
