### PR TITLE
new

### DIFF
--- a/src/agent/hybridagent/r/rtkit.cil
+++ b/src/agent/hybridagent/r/rtkit.cil
@@ -1,0 +1,94 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block rtkit
+
+       (blockinherit .dbus.nameclient.template)
+       (blockinherit .sys.agent.template)
+
+       (allow subj self (capability (setgid setuid sys_chroot sys_nice)))
+       (allow subj self (cap_userns (sys_ptrace)))
+       (allow subj self (process (setcap setrlimit setsched)))
+       (allow subj self create_unix_dgram_socket)
+       (dontaudit subj self (capability (sys_ptrace)))
+
+       (call client.sendmsg_all_dbus.type (subj))
+       (call client.setsched_all_processes (subj))
+
+       (call .crypto.read_sysctlfile_pattern.type (subj))
+
+       (call .nss.passwdgroup.type (subj))
+
+       (call .proc.list_fs_dirs (subj))
+
+       (call .selinux.linked.type (subj))
+
+       (call .subj.common.getsched_all_processes (subj))
+       (call .subj.common.read_all_states (subj))
+       (call .subj.dontaudit_read_all_states (subj))
+
+       (call .sys.getsched_subj_processes (subj))
+       (call .sys.read_subj_states (subj))
+
+       (call .sys.user.getsched_subj_processes (subj))
+       (call .sys.user.read_subj_states (subj))
+       (call .sys.user.sendmsg_subj_dbus.type (subj))
+       (call .sys.user.setsched_subj_processes (subj))
+
+       (call .systemd.journal.relay_msgs.type (subj))
+
+       (optional rtkit_polkit
+		 (call .polkit.sendmsg_subj_dbus.type (subj)))
+
+       (block cli
+
+	      (blockinherit .dbus.client.template)
+	      (blockinherit .hybrid.agent.template)
+
+	      (allow subj self create_unix_stream_socket)
+
+	      (call rtkit.sendmsg_subj_dbus.type (subj))
+
+	      (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	      (call .rbacsep.constrained.type (subj))
+
+	      (call .selinux.linked.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/rtkitctl" file file_context)))
+
+       (block client
+
+	      (macro setsched_all_processes ((type ARG1))
+		     (allow ARG1 typeattr (process (setsched))))
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (typeattribute typeattr)
+
+	      (call sendmsg_subj_dbus.type (typeattr))
+
+	      (block sendmsg_all_dbus
+
+		     (macro type ((type ARG1))
+			    (typeattributeset typeattr ARG1))
+
+		     (typeattribute typeattr)
+
+		     (allow client.typeattr typeattr (dbus (send_msg)))))
+
+       (block exec
+
+	      (filecon "/usr/bin/rtkit-daemon" file file_context))
+
+       (block unit
+
+	      (filecon "/usr/lib/systemd/system/rtkit-daemon\.service.*" file
+		       file_context)
+
+	      (blockinherit .file.unit.template)
+
+	      (call .dbus.activated.unit.type (file))))

--- a/src/agent/useragent/p/pipewire.cil
+++ b/src/agent/useragent/p/pipewire.cil
@@ -28,12 +28,16 @@
 
        (call .dbus.client.type (subj))
 
+       (call .root.list_file_dirs (subj))
+
        (call .snd.map_nodedev_chr_files (subj))
        (call .snd.readwrite_nodedev_chr_files (subj))
 
        (call .sys.modulerequest_subj_system (subj))
 
        (call .user.dbus.client.type (subj))
+
+       (call .user.home.conf.search_file_pattern.type (subj))
 
        (call .user.run.deletename_file_dirs (subj))
 
@@ -67,6 +71,8 @@
 	      (call .locale.read_file_pattern.type (typeattr))
 
 	      (call .nss.passwdgroup.type (typeattr))
+
+	      (call .rtkit.client.type (typeattr))
 
 	      (call .selinux.linked.type (typeattr))
 

--- a/src/agent/useragent/p/pipewirepulse.cil
+++ b/src/agent/useragent/p/pipewirepulse.cil
@@ -46,6 +46,8 @@
 
 	   (call .user.dbus.nameclient.type (subj))
 
+	   (call .user.home.conf.search_file_pattern.type (subj))
+
 	   (call .user.run.deletename_file_dirs (subj))
 
 	   (call .user.systemd.agent (subj exec.file))

--- a/src/agent/useragent/w/wireplumber.cil
+++ b/src/agent/useragent/w/wireplumber.cil
@@ -10,12 +10,17 @@
        (allow subj self create_netlink_kobject_uevent_socket)
        (allow subj self (bluetooth_socket (listen)))
 
+       (call data.list_file_dirs (subj))
+       (call data.map_file_files (subj))
        (call data.read_file_files (subj))
-       (call data.search_file_dirs (subj))
 
        (call home.conf.manage_file_dirs (subj))
        (call home.conf.manage_file_files (subj))
        (call home.conf.user_home_conf_file_type_transition_file (subj))
+
+       (call home.data.manage_file_dirs (subj))
+       (call home.data.manage_file_files (subj))
+       (call home.data.user_home_data_file_type_transition_file (subj))
 
        (call .bus.list_sysfile_pattern.type (subj))
        (call .bus.read_sysfile_lnk_files (subj))
@@ -42,6 +47,8 @@
 
        (call .user.home.conf.create_file_dir_pattern.type (subj))
 
+       (call .user.home.data.create_file_dir_pattern.type (subj))
+
        (call .user.dbus.nameclient.type (subj))
 
        (call .user.run.search_file_pattern.type (subj))
@@ -65,6 +72,9 @@
 		     (call .data.file_type_transition
 			   (ARG1 file dir "wireplumber")))
 
+	      (macro map_file_files ((type ARG1))
+		     (allow ARG1 file (file (map))))
+
 	      (blockinherit .file.data.template))
 
        (block exec
@@ -86,7 +96,21 @@
 
 		     (blockinherit .file.macro_template_dirs)
 		     (blockinherit .file.macro_template_files)
-		     (blockinherit .file.user.home.conf.base_template)))
+		     (blockinherit .file.user.home.conf.base_template))
+
+	      (block data
+
+		     (filecon "HOME_DIR/\.local/state/wireplumber" dir
+			      file_context)
+		     (filecon "HOME_DIR/\.local/state/wireplumber/.*" any
+			      file_context)
+
+		     (macro user_home_data_file_type_transition_file
+			    ((type ARG1))
+			    (call .user.home.data.file_type_transition
+				  (ARG1 file dir "wireplumber")))
+
+		     (blockinherit .file.user.home.data.template)))
 
        (block unit
 
@@ -134,6 +158,8 @@
 
     (call .wireplumber.data.data_file_type_transition_file (typeattr))
     (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr))
+    (call .wireplumber.home.data.user_home_data_file_type_transition_file
 	  (typeattr)))
 
 (in pipewire
@@ -148,6 +174,12 @@
     (call .wireplumber.home.conf.relabel_file_dirs (subj))
     (call .wireplumber.home.conf.relabel_file_files (subj))
     (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
+	  (subj))
+    (call .wireplumber.home.data.manage_file_dirs (subj))
+    (call .wireplumber.home.data.manage_file_files (subj))
+    (call .wireplumber.home.data.relabel_file_dirs (subj))
+    (call .wireplumber.home.data.relabel_file_files (subj))
+    (call .wireplumber.home.data.user_home_data_file_type_transition_file
 	  (subj))
     (call .wireplumber.role (role))
     (call .wireplumber.util.role (role)))


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
- hwdb is in /usr/lib/udev and setupcon can't be rbacsep constrained
- dosfstools systemd-fsck: might be a leak
- adds pipewire and wireplumber
- adds rtkit
