### PR TITLE
new

### DIFF
--- a/src/agent/misc/dbus/userdbus.cil
+++ b/src/agent/misc/dbus/userdbus.cil
@@ -9,17 +9,15 @@
 
 (in user
 
-    (call dbus.role (role))
-
     (call dbus.home.data.manage_file_files (subj))
     (call dbus.home.data.map_file_files (subj))
     (call dbus.home.data.relabel_file_files (subj))
     (call dbus.home.data.user_home_data_file_type_transition_file (subj))
-
+    (call dbus.role (role))
     (call dbus.run.manage_file_sock_files (subj))
     (call dbus.run.relabel_file_sock_files (subj))
     (call dbus.run.user_run_file_type_transition_file (subj))
-
+    (call dbus.subj_type_transition (subj))
     (call dbus.tmpfs.manage_file_files (subj))
     (call dbus.tmpfs.map_file_files (subj))
     (call dbus.tmpfs.relabel_file_files (subj))

--- a/src/agent/misc/mpd/mpd.cil
+++ b/src/agent/misc/mpd/mpd.cil
@@ -1,0 +1,188 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .mpd.conf.conf_file_type_transition_file (typeattr))
+    (call .mpd.log.log_file_type_transition_file (typeattr))
+    (call .mpd.run.run_file_type_transition_file (typeattr))
+    (call .mpd.state.state_file_type_transition_file (typeattr)))
+
+(in mpd
+
+    (macro unix_stream_connect ((type ARG1))
+	   (call connectto_subj_unix_stream_sockets (ARG1))
+	   (call run.search_file_dirs (ARG1))
+	   (call run.write_file_sock_files (ARG1)))
+
+    (blockinherit .agent.template)
+
+    (allow subj self (capability (dac_override dac_read_search setgid setuid)))
+
+    (call common.type (subj))
+
+    (call conf.read_file_files (subj))
+
+    (call log.append_file_files (subj))
+    (call log.create_file_files (subj))
+    (call log.manage_file_dirs (subj))
+    (call log.read_file_files (subj))
+
+    (call run.manage_file_dirs (subj))
+    (call run.manage_file_files (subj))
+    (call run.manage_file_sock_files (subj))
+
+    (call state.manage_file_dirs (subj))
+    (call state.manage_file_files (subj))
+
+    (call tmpfs.manage_file_files (subj))
+    (call tmpfs.map_file_files (subj))
+    (call tmpfs.tmp_fs_type_transition_file (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (call .sys.agent.type (subj))
+
+    (call .systemd.notify.type (subj))
+
+    (call .tmp.deletename_fs_dirs (subj))
+
+    (block common
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (typeattribute typeattr)
+
+	   (allow typeattr self (process (getsched setrlimit setsched)))
+	   (allow typeattr self create_tcp_stream_socket)
+	   (allow typeattr self create_unix_dgram_socket)
+	   (allow typeattr self (unix_stream_socket (accept listen)))
+
+	   (call namebind_port_tcp_sockets (typeattr))
+
+	   (call exec.entrypoint_file_files (typeattr))
+	   (call exec.mapexecute_file_files (typeattr))
+	   (call exec.read_file_files (typeattr))
+
+	   (call .cert.read_file_files (typeattr))
+	   (call .cert.traverse_file_pattern.type (typeattr))
+
+	   (call .ci.getattr_fs_pattern.type (typeattr))
+	   (call .ci.manage_fs_pattern.type (typeattr))
+
+	   (call .cpu.list_sysfile_dirs (typeattr))
+
+	   (call .crypto.read_sysctlfile_pattern.type (typeattr))
+
+	   (call .devices.search_sysfile_pattern.type (typeattr))
+
+	   (call .dos.getattr_fs_pattern.type (typeattr))
+	   (call .dos.manage_fs_pattern.type (typeattr))
+
+	   (call .fuse.getattr_fs_pattern.type (typeattr))
+	   (call .fuse.manage_fs_pattern.type (typeattr))
+
+	   (call .locale.data.map_file_pattern.type (typeattr))
+	   (call .locale.read_file_pattern.type (typeattr))
+
+	   (call .net.nodebind_netnode_tcp_sockets (typeattr))
+
+	   (call .net.read_procfile_pattern.type (typeattr))
+
+	   (call .nfs.getattr_fs_pattern.type (typeattr))
+	   (call .nfs.manage_fs_pattern.type (typeattr))
+
+	   (call .node.read_sysfile_pattern.type (typeattr))
+
+	   (call .nss.hosts.type (typeattr))
+	   (call .nss.passwdgroup.type (typeattr))
+
+	   (call .random.read_nodedev_chr_files (typeattr))
+
+	   (call .selinux.linked.type (typeattr))
+
+	   (call .shout.namebind_port_tcp_sockets (typeattr))
+	   (call .shout.nameconnect_port_tcp_sockets (typeattr))
+
+	   (call .systemd.journal.relay_msgs.type (typeattr)))
+
+    (block conf
+
+	   (filecon "/etc/mpd\.conf" file file_context)
+	   (filecon "/etc/mpd\.conf\..*" file file_context)
+
+	   (macro conf_file_type_transition_file ((type ARG1))
+		  (call .conf.file_type_transition
+			(ARG1 file file "mpd.conf")))
+
+	   (blockinherit .file.conf.base_template)
+	   (blockinherit .file.macro_template_files))
+
+    (block exec
+
+	   (filecon "/usr/bin/mpd" file file_context)
+
+	   (call .hybrid.agent.exec.type (file)))
+
+    (block log
+
+	   (filecon "/var/log/mpd" dir file_context)
+	   (filecon "/var/log/mpd/.*" any file_context)
+
+	   (macro log_file_type_transition_file ((type ARG1))
+		  (call .log.file_type_transition
+			(ARG1 file dir "mpd")))
+
+	   (blockinherit .file.log.template))
+
+    (block run
+
+	   (filecon "/run/mpd" dir file_context)
+	   (filecon "/run/mpd/.*" any file_context)
+
+	   (macro run_file_type_transition_file ((type ARG1))
+		  (call .run.file_type_transition
+			(ARG1 file dir "mpd")))
+
+	   (blockinherit .file.macro_template_dirs)
+	   (blockinherit .file.macro_template_files)
+	   (blockinherit .file.macro_template_sock_files)
+	   (blockinherit .file.run.base_template))
+
+    (block state
+
+	   (filecon "/var/lib/mpd" dir file_context)
+	   (filecon "/var/lib/mpd/.*" any file_context)
+
+	   (macro state_file_type_transition_file ((type ARG1))
+		  (call .state.file_type_transition
+			(ARG1 file dir "mpd")))
+
+	   (blockinherit .file.macro_template_dirs)
+	   (blockinherit .file.macro_template_files)
+	   (blockinherit .file.state.base_template))
+
+    (block tmpfs
+
+	   (macro map_file_files ((type ARG1))
+		  (allow ARG1 file (file (map))))
+
+	   (macro tmp_fs_type_transition_file ((type ARG1))
+		  (call .tmp.fs_type_transition
+			(ARG1 file file "*")))
+
+	   (blockinherit .file.macro_template_files)
+	   (blockinherit .file.tmpfs.base_template))
+
+    (block unit
+
+	   (filecon "/usr/lib/systemd/system/mpd\.service.*" file file_context)
+	   (filecon "/usr/lib/systemd/system/mpd\.socket.*" file file_context)
+
+	   (blockinherit .file.unit.template)))
+
+(in sys
+
+    (call .mpd.subj_type_transition (subj)))

--- a/src/agent/misc/mpd/usermpd.cil
+++ b/src/agent/misc/mpd/usermpd.cil
@@ -1,0 +1,166 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .user.mpd.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr))
+    (call .user.mpd.home.conf.user_home_file_type_transition_file (typeattr)))
+
+(in user
+
+    (call mpd.home.conf.manage_file_dirs (subj))
+    (call mpd.home.conf.manage_file_files (subj))
+    (call mpd.home.conf.map_file_files (subj))
+    (call mpd.home.conf.relabel_file_dirs (subj))
+    (call mpd.home.conf.relabel_file_files (subj))
+    (call mpd.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call mpd.home.conf.user_home_file_type_transition_file (subj))
+    (call mpd.role (role))
+    (call mpd.subj_type_transition (subj))
+    (call mpd.run.manage_file_dirs (subj))
+    (call mpd.run.manage_file_sock_files (subj))
+    (call mpd.run.relabel_file_dirs (subj))
+    (call mpd.run.relabel_file_sock_files (subj))
+    (call mpd.run.user_run_file_type_transition_file (subj))
+    (call mpd.tmpfs.manage_file_files (subj))
+    (call mpd.tmpfs.relabel_file_files (subj))
+
+    (block mpd
+
+	   (macro connectto_subj_unix_stream_sockets ((type ARG1))
+		  (allow ARG1 subj (unix_stream_socket (connectto))))
+
+	   (macro role ((role ARG1))
+		  (roleattributeset roleattr ARG1))
+
+	   (macro subj_type_transition ((type ARG1))
+		  (allow ARG1 subj (process (transition)))
+
+		  (allow subj ARG1 (process (sigchld)))
+		  (allow subj ARG1 (fd (use)))
+		  (allow subj ARG1 readwriteinherited_fifo_file)
+
+		  (call .mpd.exec.mapexecute_file_files (ARG1))
+		  (call .mpd.exec.read_file_files (ARG1))
+		  (call .mpd.exec.subj_type_transition (ARG1 subj)))
+
+	   (macro unix_stream_connect ((type ARG1))
+		  (call connectto_subj_unix_stream_sockets (ARG1))
+		  (call run.search_file_dirs (ARG1))
+		  (call run.write_file_sock_files (ARG1)))
+
+	   (blockinherit .subj.common.base_template)
+
+	   (roleattribute roleattr)
+	   (roletype roleattr subj)
+
+	   (call home.conf.manage_file_files (subj))
+	   (call home.conf.readwrite_file_dirs (subj))
+
+	   (call run.manage_file_dirs (subj))
+	   (call run.manage_file_sock_files (subj))
+	   (call run.user_run_file_type_transition_file (subj))
+
+	   (call tmpfs.manage_file_files (subj))
+	   (call tmpfs.map_file_files (subj))
+	   (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	   (call .media.search_file_dirs (subj))
+
+	   (call .media.home.traverse_file_pattern.type (subj))
+
+	   (call .mpd.common.type (subj))
+
+	   (call .pipewire.pulse.client.type (subj))
+
+	   (call .runuser.search_file_pattern.type (subj))
+
+	   (call .user.agent.type (subj))
+
+	   (call .user.home.list_file_dirs (subj))
+	   (call .user.home.read_file_files (subj))
+	   (call .user.home.read_file_lnk_files (subj))
+
+	   (call .user.home.conf.search_file_pattern.type (subj))
+
+	   (call .user.run.deletename_file_dirs (subj))
+
+	   (call .user.systemd.agent (subj .mpd.exec.file))
+	   (call .user.systemd.notify.type (subj))
+	   (call .user.systemd.service.nnptransition.type (subj))
+	   (call .user.systemd.socketactivated.tcp.type (subj))
+	   (call .user.systemd.socketactivated.unixstream.type (subj))
+
+	   (block home
+
+		  (block conf
+
+			 (filecon "HOME_DIR/\.config/mpd" dir file_context)
+			 (filecon "HOME_DIR/\.config/mpd/.*" any file_context)
+
+			 (filecon "HOME_DIR/\.mpd" dir file_context)
+			 (filecon "HOME_DIR/\.mpd/.*" any file_context)
+
+			 (filecon "HOME_DIR/\.mpdconf" file file_context)
+			 (filecon "HOME_DIR/\.mpdconf\..*" file file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_conf_file_type_transition_file
+				((type ARG1))
+				(call .user.home.conf.file_type_transition
+				      (ARG1 file dir "mpd")))
+
+			 (macro user_home_file_type_transition_file
+				((type ARG1))
+				(call .user.home.file_type_transition
+				      (ARG1 file dir ".mpd"))
+				(call .user.home.file_type_transition
+				      (ARG1 file file ".mpdconf")))
+
+			 (blockinherit .file.user.home.conf.template)))
+
+	   (block run
+
+		  (filecon "/run/user/%{USERID}/mpd" dir file_context)
+		  (filecon "/run/user/%{USERID}/mpd/.*" any file_context)
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro user_run_file_type_transition_file ((type ARG1))
+			 (call .user.run.file_type_transition
+			       (ARG1 file dir "mpd")))
+
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_sock_files)
+		  (blockinherit .file.user.run.base_template)
+
+		  (call .user.systemd.socketactivated.type (file)))
+
+	   (block tmpfs
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro tmp_fs_type_transition_file ((type ARG1))
+			 (call .tmp.fs_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.user.tmpfs.base_template))
+
+	   (block unit
+
+		  (filecon "/usr/lib/systemd/user/mpd\.service.*" file
+			   file_context)
+		  (filecon "/usr/lib/systemd/user/mpd\.socket.*" file
+			   file_context)
+
+		  (blockinherit .file.user.unit.template))))
+
+(in wheel
+
+    (call .user.mpd.role (role)))

--- a/src/agent/misc/systemd/systemdrun.cil
+++ b/src/agent/misc/systemd/systemdrun.cil
@@ -5,6 +5,10 @@
 
     (call .systemd.run.pipe.client.type (subj)))
 
+(in sys
+
+    (call .systemd.run.subj_type_transition (subj)))
+
 (in systemd.run
 
     (macro agent ((type ARG1)(type ARG2))

--- a/src/agent/misc/systemd/usersystemdtmpfiles.cil
+++ b/src/agent/misc/systemd/usersystemdtmpfiles.cil
@@ -14,9 +14,6 @@
 
 (in user
 
-    (call systemd.tmpfiles.role (role))
-    (call systemd.tmpfiles.subj_type_transition (subj))
-
     (call systemd.tmpfiles.home.conf.manage_file_dirs (subj))
     (call systemd.tmpfiles.home.conf.manage_file_files (subj))
     (call systemd.tmpfiles.home.conf.map_file_files (subj))
@@ -24,7 +21,8 @@
     (call systemd.tmpfiles.home.conf.relabel_file_files (subj))
     (call systemd.tmpfiles.home.conf.user_home_conf_file_type_transition_file
 	  (subj))
-
+    (call systemd.tmpfiles.role (role))
+    (call systemd.tmpfiles.subj_type_transition (subj))
     (call systemd.tmpfiles.home.data.manage_file_dirs (subj))
     (call systemd.tmpfiles.home.data.manage_file_files (subj))
     (call systemd.tmpfiles.home.data.map_file_files (subj))
@@ -32,7 +30,6 @@
     (call systemd.tmpfiles.home.data.relabel_file_files (subj))
     (call systemd.tmpfiles.home.data.user_home_data_file_type_transition_file
 	  (subj))
-
     (call systemd.tmpfiles.run.manage_file_dirs (subj))
     (call systemd.tmpfiles.run.manage_file_files (subj))
     (call systemd.tmpfiles.run.map_file_files (subj))

--- a/src/agent/useragent/m/mpc.cil
+++ b/src/agent/useragent/m/mpc.cil
@@ -1,0 +1,178 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .mpd.ncmpc.conf.conf_file_type_transition_file (typeattr))
+    (call .mpd.ncmpc.data.data_file_type_transition_file (typeattr))
+    (call .mpd.ncmpc.home.cache.user_home_cache_file_type_transition_file
+	  (typeattr))
+    (call .mpd.ncmpc.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr))
+    (call .mpd.ncmpc.home.conf.user_home_file_type_transition_file (typeattr)))
+
+(in mpd
+
+    (block ncmpc
+
+	   (blockinherit .user.agent.template)
+
+	   (allow subj self (process (getsched setsched)))
+	   (allow subj self create_tcp_socket)
+	   (allow subj self create_unix_stream_socket)
+
+	   (call nameconnect_port_tcp_sockets (subj))
+
+	   (call unix_stream_connect (subj))
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call data.execute_file_files (subj))
+	   (call data.list_file_dirs (subj))
+
+	   (call home.cache.manage_file_dirs (subj))
+	   (call home.cache.manage_file_files (subj))
+	   (call home.cache.user_home_cache_file_type_transition_file (subj))
+
+	   (call home.conf.list_file_dirs (subj))
+	   (call home.conf.read_file_files (subj))
+
+	   (call tmp.manage_file_files (subj))
+	   (call tmp.tmp_file_type_transition_file (subj))
+
+	   (call .cert.read_file_files (subj))
+	   (call .cert.traverse_file_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .exec.execute_file_files (subj))
+
+	   (call .http.https.nameconnect_port_tcp_sockets (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .nss.hosts.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .shell.exec.mapexecute_file_files (subj))
+	   (call .shell.exec.read_file_files (subj))
+
+	   (call .terminfo.read_file_pattern.type (subj))
+
+	   (call .user.home.cache.create_file_dir_pattern.type (subj))
+
+	   (call .user.home.conf.search_file_pattern.type (subj))
+
+	   (call .user.run.search_file_pattern.type (subj))
+
+	   (optional mpc_usermpd
+		     (call .user.mpd.unix_stream_connect (subj)))
+
+	   (block conf
+
+		  (filecon "/etc/ncmpc" dir file_context)
+		  (filecon "/etc/ncmpc/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "ncmpc")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block data
+
+		  (filecon "/usr/share/ncmpc" dir file_context)
+		  (filecon "/usr/share/ncmpc/.*" any file_context)
+
+		  (macro data_file_type_transition_file ((type ARG1))
+			 (call .data.file_type_transition
+			       (ARG1 file dir "ncmpc")))
+
+		  (blockinherit .file.data.base_template)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files))
+
+	   (block exec
+
+		  (filecon "/usr/bin/mpc" file file_context)
+		  (filecon "/usr/bin/ncmpc" file file_context))
+
+	   (block home
+
+		  (block cache
+
+			 (filecon "HOME_DIR/\.cache/ncmpc" dir file_context)
+			 (filecon "HOME_DIR/\.cache/ncmpc/.*" any file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_cache_file_type_transition_file
+				((type ARG1))
+				(call .user.home.cache.file_type_transition
+				      (ARG1 file dir "ncmpc")))
+
+			 (blockinherit .file.user.home.cache.template))
+
+		  (block conf
+
+			 (filecon "HOME_DIR/\.config/ncmpc" dir file_context)
+			 (filecon "HOME_DIR/\.config/ncmpc/.*" any file_context)
+
+			 (filecon "HOME_DIR/\.lyrics" dir file_context)
+			 (filecon "HOME_DIR/\.lyrics/.*" any file_context)
+			 (filecon "HOME_DIR/\.ncmpc" dir file_context)
+			 (filecon "HOME_DIR/\.ncmpc/.*" any file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_conf_file_type_transition_file
+				((type ARG1))
+				(call .user.home.conf.file_type_transition
+				      (ARG1 file dir "ncmpc")))
+
+			 (macro user_home_file_type_transition_file
+				((type ARG1))
+				(call .user.home.file_type_transition
+				      (ARG1 file dir ".lyrics"))
+				(call .user.home.file_type_transition
+				      (ARG1 file dir ".ncmpc")))
+
+			 (blockinherit .file.user.home.conf.template)))
+
+	   (block tmp
+
+		  (macro tmp_file_type_transition_file ((type ARG1))
+			 (call .tmp.file_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.user.tmp.base_template))))
+
+(in user
+
+    (call .mpd.ncmpc.home.cache.manage_file_dirs (subj))
+    (call .mpd.ncmpc.home.cache.manage_file_files (subj))
+    (call .mpd.ncmpc.home.cache.map_file_files (subj))
+    (call .mpd.ncmpc.home.cache.relabel_file_dirs (subj))
+    (call .mpd.ncmpc.home.cache.relabel_file_files (subj))
+    (call .mpd.ncmpc.home.cache.user_home_cache_file_type_transition_file
+	  (subj))
+    (call .mpd.ncmpc.home.conf.manage_file_dirs (subj))
+    (call .mpd.ncmpc.home.conf.manage_file_files (subj))
+    (call .mpd.ncmpc.home.conf.map_file_files (subj))
+    (call .mpd.ncmpc.home.conf.relabel_file_dirs (subj))
+    (call .mpd.ncmpc.home.conf.relabel_file_files (subj))
+    (call .mpd.ncmpc.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call .mpd.ncmpc.home.conf.user_home_file_type_transition_file (subj))
+    (call .mpd.ncmpc.role (role))
+    (call .mpd.ncmpc.tmp.manage_file_files (subj))
+    (call .mpd.ncmpc.tmp.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .mpd.ncmpc.role (role)))

--- a/src/agent/useragent/p/pipewire.cil
+++ b/src/agent/useragent/p/pipewire.cil
@@ -33,6 +33,8 @@
        (call .snd.map_nodedev_chr_files (subj))
        (call .snd.readwrite_nodedev_chr_files (subj))
 
+       (call .state.search_file_pattern.type (subj))
+
        (call .sys.modulerequest_subj_system (subj))
 
        (call .user.dbus.client.type (subj))

--- a/src/agent/useragent/w/wireplumber.cil
+++ b/src/agent/useragent/w/wireplumber.cil
@@ -14,10 +14,6 @@
        (call data.map_file_files (subj))
        (call data.read_file_files (subj))
 
-       (call home.conf.manage_file_dirs (subj))
-       (call home.conf.manage_file_files (subj))
-       (call home.conf.user_home_conf_file_type_transition_file (subj))
-
        (call home.data.manage_file_dirs (subj))
        (call home.data.manage_file_files (subj))
        (call home.data.user_home_data_file_type_transition_file (subj))
@@ -44,8 +40,6 @@
        (call .state.search_file_pattern.type (subj))
 
        (call .systemd.udev.run.read_file_pattern.type (subj))
-
-       (call .user.home.conf.create_file_dir_pattern.type (subj))
 
        (call .user.home.data.create_file_dir_pattern.type (subj))
 
@@ -83,21 +77,6 @@
 
        (block home
 
-	      (block conf
-
-		     (filecon "HOME_DIR/\.config/wireplumber" dir file_context)
-		     (filecon "HOME_DIR/\.config/wireplumber/.*" any
-			      file_context)
-
-		     (macro user_home_conf_file_type_transition_file
-			    ((type ARG1))
-			    (call .user.home.conf.file_type_transition
-				  (ARG1 file dir "wireplumber")))
-
-		     (blockinherit .file.macro_template_dirs)
-		     (blockinherit .file.macro_template_files)
-		     (blockinherit .file.user.home.conf.base_template))
-
 	      (block data
 
 		     (filecon "HOME_DIR/\.local/state/wireplumber" dir
@@ -127,8 +106,8 @@
 
 	      (allow subj self (process (getsched setsched)))
 
-	      (call home.conf.read_file_files (subj))
-	      (call home.conf.search_file_dirs (subj))
+	      (call home.data.read_file_files (subj))
+	      (call home.data.search_file_dirs (subj))
 
 	      (call .crypto.read_sysctlfile_pattern.type (subj))
 
@@ -137,15 +116,15 @@
 
 	      (call .nss.passwdgroup.type (subj))
 
+	      (call .pipewire.data.list_file_dirs (subj))
 	      (call .pipewire.data.map_file_files (subj))
 	      (call .pipewire.data.read_file_files (subj))
-	      (call .pipewire.data.search_file_dirs (subj))
 
 	      (call .pipewire.unix_stream_connect (subj))
 
 	      (call .selinux.linked.type (subj))
 
-	      (call .user.home.conf.search_file_pattern.type (subj))
+	      (call .user.home.data.search_file_pattern.type (subj))
 
 	      (call .user.run.search_file_pattern.type (subj))
 
@@ -157,8 +136,6 @@
 (in file.unconfined
 
     (call .wireplumber.data.data_file_type_transition_file (typeattr))
-    (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
-	  (typeattr))
     (call .wireplumber.home.data.user_home_data_file_type_transition_file
 	  (typeattr)))
 
@@ -169,12 +146,6 @@
 
 (in user
 
-    (call .wireplumber.home.conf.manage_file_dirs (subj))
-    (call .wireplumber.home.conf.manage_file_files (subj))
-    (call .wireplumber.home.conf.relabel_file_dirs (subj))
-    (call .wireplumber.home.conf.relabel_file_files (subj))
-    (call .wireplumber.home.conf.user_home_conf_file_type_transition_file
-	  (subj))
     (call .wireplumber.home.data.manage_file_dirs (subj))
     (call .wireplumber.home.data.manage_file_files (subj))
     (call .wireplumber.home.data.relabel_file_dirs (subj))

--- a/src/net/portnet/unreservedportnet/s/shoutunreservedport.cil
+++ b/src/net/portnet/unreservedportnet/s/shoutunreservedport.cil
@@ -1,0 +1,11 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block shout
+
+       (portcon "dccp" (8000 8001) port_context)
+       (portcon "sctp" (8000 8001) port_context)
+       (portcon "tcp" (8000 8001) port_context)
+       (portcon "udp" (8000 8001) port_context)
+
+       (blockinherit .net.port.unreserved.template))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -190,6 +190,9 @@
 	      (call .polkit.check.role (role))
 	      (call .polkit.ttyagent.role (role)))
 
+    (optional unprivuser_rtkit
+	      (call .rtkit.cli.role (role)))
+
     (optional unprivuser_systemddissect
 	      (call .systemd.dissect.role (role))
 	      (call .systemd.dissect.tmp.manage_file_dirs (subj))

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -65,6 +65,9 @@
 		 (call .polkit.check.role (role))
 		 (call .polkit.ttyagent.role (role)))
 
+       (optional wheeluser_rtkit
+		 (call .rtkit.cli.role (role)))
+
        (optional wheeluser_systemddissect
 		 (call .systemd.dissect.role (role)))
 


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
- hwdb is in /usr/lib/udev and setupcon can't be rbacsep constrained
- dosfstools systemd-fsck: might be a leak
- adds pipewire and wireplumber
- adds rtkit
- rtkit cli access
- pipewire and wireplumber
- adds mpd
