### PR TITLE
new

### DIFF
--- a/src/agent/useragent/p/pipewirepulse.cil
+++ b/src/agent/useragent/p/pipewirepulse.cil
@@ -42,6 +42,8 @@
 
 	   (call .dbus.client.type (subj))
 
+	   (call .root.list_file_dirs (subj))
+
 	   (call .tmp.deletename_fs_dirs (subj))
 
 	   (call .user.dbus.nameclient.type (subj))


### PR DESCRIPTION
- ifupdown: move this to where it belongs
- networkctl: i think this was meant to be for networkctl
- networkctl: hwdb.bin is not there in debian
- various
- gh for fg run view N --log-failed
- gh: forgot this
- irqbalance maintains a runtime dir after all
- adds more groff data
- setupcon and initramfs
- emacsclient traverses ~/.config
- emacs/user/usersandbox: mime read access
- adds reprepro perl5 conffile
- hwdb is in /usr/lib/udev and setupcon can't be rbacsep constrained
- dosfstools systemd-fsck: might be a leak
- adds pipewire and wireplumber
- adds rtkit
- rtkit cli access
- pipewire and wireplumber
- adds mpd
- mpd
- pipewire pulse
