### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/systemd/systemdhostnamectl.cil
+++ b/src/agent/misc/systemd/systemdhostnamectl.cil
@@ -29,6 +29,8 @@
 
 	   (call .machineid.read_file_files (subj))
 
+	   (call .ns.read_fs_pattern.type (subj))
+
 	   (call .proc.getattr_fs_pattern.type (subj))
 
 	   (call .random.read_sysctlfile_pattern.type (subj))

--- a/src/agent/misc/systemdcontainer/systemdimport.cil
+++ b/src/agent/misc/systemdcontainer/systemdimport.cil
@@ -75,6 +75,8 @@
     (call .selinux.file.read_file_pattern.type (subj))
     (call .selinux.mapread_fs_pattern.type (subj))
 
+    (call .sys.tmp.readinherited_file_files (subj))
+
     (call .tmp.deletename_file_dirs (subj))
 
     (call .manage_unlabeled_chr_files (subj))

--- a/src/agent/misc/systemdcontainer/systemdmachine.cil
+++ b/src/agent/misc/systemdcontainer/systemdmachine.cil
@@ -113,6 +113,7 @@
 	   (call systemd.nspawn.container.obj.delete_all_lnk_files (subj))
 	   (call systemd.nspawn.container.obj.delete_all_sock_files (subj))
 
+	   (call systemd.nspawn.container.obj.getattr_all_fs (subj))
 	   (call systemd.nspawn.container.obj.manage_all_files (subj))
 	   (call systemd.nspawn.container.obj.read_all_lnk_files (subj))
 	   (call systemd.nspawn.container.obj.readwrite_all_chr_files (subj))
@@ -271,12 +272,11 @@
 
     (call .user.home.readinherited_file_files (subj)))
 
-;; TODO
-;;(in systemd.journalctl
-;;
-;;    (blockinherit .dbus.client.template)
-;;
-;;    (call systemd.machine.sendmsg_subj_dbus.type (subj)))
+(in systemd.journalctl
+
+    (blockinherit .dbus.client.template)
+
+    (call systemd.machine.sendmsg_subj_dbus.type (subj)))
 
 (in systemd.stdiobridge
 

--- a/src/agent/misc/systemdcontainer/systemdmachinectl.cil
+++ b/src/agent/misc/systemdcontainer/systemdmachinectl.cil
@@ -75,7 +75,7 @@
 	   (call .sys.sendmsg_subj_dbus.type (subj))
 	   (call .sys.status_system (subj))
 
-	   (call .sys.tmp.open_file_files (subj))
+	   (call .sys.tmp.read_file_files (subj))
 
 	   (call .tmp.getattr_fs_pattern.type (subj))
 	   (call .tmp.search_file_pattern.type (subj))

--- a/src/agent/misc/systemdcontainer/systemdnspawn.cil
+++ b/src/agent/misc/systemdcontainer/systemdnspawn.cil
@@ -38,6 +38,14 @@
     (call systemd.nspawn.container.subj.read_all_states (subj))
     (call systemd.nspawn.container.unit.status_all_services (subj)))
 
+(in systemd.hostnamectl
+
+    (allow subj self (capability (sys_admin sys_chroot)))
+    (allow subj self
+	   (cap_userns (setgid setuid sys_admin sys_chroot sys_ptrace)))
+
+    (call systemd.nspawn.container.client.type (subj)))
+
 (in systemd.import
 
     (call systemd.nspawn.container.obj.manage_all_chr_files (subj))

--- a/src/agent/misc/utillinux/mount.cil
+++ b/src/agent/misc/utillinux/mount.cil
@@ -74,6 +74,8 @@
        (call .sys.dontaudit_setsched_subj_processes (subj))
        (call .sys.modulerequest_subj_system (subj))
 
+       (call .sys.tmp.appendinherited_file_files (subj))
+
        ;; /var/run
        (call .var.read_file_lnk_files (subj))
 
@@ -168,3 +170,8 @@
 (in file.unconfined
 
     (call .mount.run.run_file_type_transition_file (typeattr)))
+
+(in sys.tmp
+
+    ;; for dssp5-debian-createtar
+    (call .mount.mountpoint.type (file)))

--- a/src/agent/sysagent/m/mandb.cil
+++ b/src/agent/sysagent/m/mandb.cil
@@ -28,6 +28,8 @@
 	   (call .rbacsep.constrained.type (subj))
 	   (call .rbacsep.usefdsource.type (subj))
 
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
 	   (block cache
 
 		  (filecon "/var/cache/man" dir file_context)

--- a/src/file/tmpfile/systmpfile.cil
+++ b/src/file/tmpfile/systmpfile.cil
@@ -14,9 +14,6 @@
 	   (macro map_file_files ((type ARG1))
 		  (allow ARG1 file (file (map))))
 
-	   (macro open_file_files ((type ARG1))
-		  (allow ARG1 file (file (open))))
-
 	   (macro tmp_file_type_transition_file
 		  ((type ARG1)(class ARG2)(name ARG3))
 		  (call .tmp.file_type_transition


### PR DESCRIPTION
- pinentry has no business with termdevs other than it own
- adds glib2 traceroute man-db
- fix glib2 fs specs
- pipewire fix typeattr
- man-db
- adds translate-shell and mpg123
- mount importd: to make dssp5-debian-createtar work
- related to nspawn container interactions
