### PR TITLE
stuff

### DIFF
--- a/src/agent/misc/mpd/mpd.cil
+++ b/src/agent/misc/mpd/mpd.cil
@@ -16,8 +16,11 @@
 	   (call run.write_file_sock_files (ARG1)))
 
     (blockinherit .agent.template)
+    (blockinherit .dbus.client.template)
 
     (allow subj self (capability (dac_override dac_read_search setgid setuid)))
+    (allow subj self create_sem)
+    (allow subj self create_shm)
 
     (call common.type (subj))
 
@@ -34,19 +37,39 @@
 
     (call state.manage_file_dirs (subj))
     (call state.manage_file_files (subj))
+    (call state.manage_file_lnk_files (subj))
+
+    (call tmp.manage_file_dirs (subj))
+    (call tmp.tmp_file_type_transition_file (subj))
 
     (call tmpfs.manage_file_files (subj))
     (call tmpfs.map_file_files (subj))
     (call tmpfs.tmp_fs_type_transition_file (subj))
 
+    (call .alsa.data.read_file_files (subj))
+    (call .alsa.data.search_file_dirs (subj))
+
+    (call .log.search_file_pattern.type (subj))
+
+    (call .ngroupsmax.read_sysctlfile_pattern.type (subj))
+
     (call .rbacsep.constrained.type (subj))
     (call .rbacsep.usefdsource.type (subj))
+
+    (call .snd.readwrite_nodedev_chr_files (subj))
+
+    (call .state.search_file_pattern.type (subj))
 
     (call .sys.agent.type (subj))
 
     (call .systemd.notify.type (subj))
 
+    (call .tmp.deletename_file_dirs (subj))
     (call .tmp.deletename_fs_dirs (subj))
+
+    (optional mpd_pipewirepulse
+	      (call .pipewire.pulse.conf.list_file_dirs (subj))
+	      (call .pipewire.pulse.conf.read_file_files (subj)))
 
     (block common
 
@@ -166,7 +189,21 @@
 
 	   (blockinherit .file.macro_template_dirs)
 	   (blockinherit .file.macro_template_files)
+	   (blockinherit .file.macro_template_lnk_files)
 	   (blockinherit .file.state.base_template))
+
+    (block tmp
+
+	   (macro map_file_files ((type ARG1))
+		  (allow ARG1 file (file (map))))
+
+	   (macro tmp_file_type_transition_file ((type ARG1))
+		  (call .tmp.file_type_transition
+			(ARG1 file dir "*")))
+
+	   (blockinherit .file.macro_template_dirs)
+	   (blockinherit .file.macro_template_files)
+	   (blockinherit .file.tmpfs.base_template))
 
     (block tmpfs
 

--- a/src/agent/misc/systemd/systemdudev.cil
+++ b/src/agent/misc/systemd/systemdudev.cil
@@ -181,6 +181,8 @@
 
 	   (call .root.auditwriteaccess_file_dirs (subj))
 
+	   (call .security.search_fs_dirs (subj))
+
 	   (call .selinux.file.read_file_pattern.type (subj))
 	   (call .selinux.mapread_fs_pattern.type (subj))
 

--- a/src/agent/sysagent/i/initramfstools.cil
+++ b/src/agent/sysagent/i/initramfstools.cil
@@ -158,6 +158,7 @@
 
 (in blktools
 
+    (call .initramfstools.read_subj_states (subj))
     (call .initramfstools.tmp.writeinherited_file_files (subj)))
 
 (in devicemapper

--- a/src/agent/sysagent/i/initramfstools.cil
+++ b/src/agent/sysagent/i/initramfstools.cil
@@ -26,6 +26,9 @@
        (call .boot.manage_file_files (subj))
        (call .boot.readwrite_file_dirs (subj))
 
+       (call .btrfs.list_sysfile_dirs (subj))
+       (call .btrfs.read_sysfile_lnk_files (subj))
+
        (call .cmdline.read_procfile_files (subj))
 
        (call .cpuinfo.read_procfile_files (subj))

--- a/src/misc.cil
+++ b/src/misc.cil
@@ -1159,18 +1159,18 @@
 	   (call lib.mapexecute_file_files (typeattr))
 	   (call lib.read_file_files (typeattr))
 
-	   (call lib.search_file_pattern.type (typeattr))))
+	   (call lib.list_file_pattern.type (typeattr))))
 
 (in glib2.gio.lib
 
-    (block search_file_pattern
+    (block list_file_pattern
 
 	   (macro type ((type ARG1))
 		  (typeattributeset typeattr ARG1))
 
 	   (typeattribute typeattr)
 
-	   (call search_file_dirs (typeattr))
+	   (call list_file_dirs (typeattr))
 
 	   (call .lib.search_file_pattern.type (typeattr))))
 

--- a/src/sys/sysfile/fssysfile/btrfssysfile.cil
+++ b/src/sys/sysfile/fssysfile/btrfssysfile.cil
@@ -6,4 +6,5 @@
        (genfscon "sysfs" "/fs/btrfs" sysfile_context)
 
        (blockinherit .sysfile.fs.template)
-       (blockinherit .sysfile.macro_template_dirs))
+       (blockinherit .sysfile.macro_template_dirs)
+       (blockinherit .sysfile.macro_template_lnk_files))

--- a/src/unlabeled.cil
+++ b/src/unlabeled.cil
@@ -361,6 +361,8 @@
 (type unlabeled)
 (roletype sys.role unlabeled)
 
+(call .xattr.associate_fs (unlabeled))
+
 (block unlabeled
 
        (block unconfined


### PR DESCRIPTION
- allows unlabeled to associate with xattr.fs
- glib2.gio.linked lists the modules dir (polkit)
- udev: must be related to apparmor
- initramfstools: blkid reads initramfstools /proc/pid/mounts
- initramfs: cryptroot access to /sys/fs/btrfs
- mpd system instance
