### PR TITLE
sway

### DIFF
--- a/src/agent/misc/wlroots.cil
+++ b/src/agent/misc/wlroots.cil
@@ -1,0 +1,103 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block wlroots
+
+       (macro type ((type ARG1))
+	      (typeattributeset typeattr ARG1))
+
+       (typeattribute typeattr)
+
+       (call .tmp.deletename_fs_dirs (typeattr))
+
+       (block client
+
+	      (macro read_all_states ((type ARG1))
+		     (allow ARG1 typeattr (state (read))))
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (macro use_all_fds ((type ARG1))
+		     (allow ARG1 typeattr (fd (use))))
+
+	      (macro writeinherited_all_fifo_files ((type ARG1))
+		     (allow ARG1 typeattr writeinherited_fifo_file))
+
+	      (typeattribute typeattr)
+
+	      (call use_all_fds (typeattr))
+	      (call writeinherited_all_fifo_files (typeattr))
+
+	      (call compositor.tmpfs.map_all_files (typeattr))
+	      (call compositor.tmpfs.readwriteinherited_all_files (typeattr))
+
+	      (call compositor.connectto_all_unix_stream_sockets (typeattr))
+	      (call compositor.use_all_fds (typeattr))
+
+	      (call wlroots.type (typeattr))
+
+	      (call .user.dontaudit_readwrite_serialtermdev_chr_files
+		    (typeattr))
+
+	      (call .user.run.search_file_pattern.type (typeattr))
+
+	      (call .wayland.run.write_file_sock_files (typeattr))
+
+	      (block tmpfs
+
+		     (macro map_all_files ((type ARG1))
+			    (allow ARG1 typeattr (file (map))))
+
+		     (macro readwriteinherited_all_files ((type ARG1))
+			    (allow ARG1 typeattr readwriteinherited_file))
+
+		     (macro type ((type ARG1))
+			    (typeattributeset typeattr ARG1))
+
+		     (typeattribute typeattr)))
+
+       (block compositor
+
+	      (macro connectto_all_unix_stream_sockets ((type ARG1))
+		     (allow ARG1 typeattr (unix_stream_socket (connectto))))
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (macro use_all_fds ((type ARG1))
+		     (allow ARG1 typeattr (fd (use))))
+
+	      (typeattribute typeattr)
+
+	      (allow typeattr self (process (execmem)))
+
+	      (call client.read_all_states (typeattr))
+	      (call client.use_all_fds (typeattr))
+	      (call client.writeinherited_all_fifo_files (typeattr))
+
+	      (call client.tmpfs.map_all_files (typeattr))
+	      (call client.tmpfs.readwriteinherited_all_files (typeattr))
+
+	      (call wlroots.type (typeattr))
+
+	      (call .runuser.search_file_pattern.type (typeattr))
+
+	      (call .user.run.deletename_file_dirs (typeattr))
+
+	      (call .wayland.run.manage_file_files (typeattr))
+	      (call .wayland.run.manage_file_sock_files (typeattr))
+	      (call .wayland.run.user_run_file_type_transition_file (typeattr))
+
+	      (block tmpfs
+
+		     (macro map_all_files ((type ARG1))
+			    (allow ARG1 typeattr (file (map))))
+
+		     (macro readwriteinherited_all_files ((type ARG1))
+			    (allow ARG1 typeattr readwriteinherited_file))
+
+		     (macro type ((type ARG1))
+			    (typeattributeset typeattr ARG1))
+
+		     (typeattribute typeattr))))

--- a/src/agent/useragent/f/foot.cil
+++ b/src/agent/useragent/f/foot.cil
@@ -1,0 +1,192 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block foot
+
+       (macro unix_stream_connect ((type ARG1))
+	      (call connectto_subj_unix_stream_sockets (ARG1))
+	      (call run.write_file_sock_files (ARG1)))
+
+       (blockinherit .user.agent.template)
+
+       (allow subj self (process (getsched)))
+       (allow subj self create_unix_dgram_socket)
+       (allow subj self (unix_stream_socket (accept listen)))
+
+       (call home.conf.list_file_dirs (subj))
+       (call home.conf.read_file_files (subj))
+       (call home.conf.read_file_lnk_files (subj))
+
+       (call run.manage_file_sock_files (subj))
+       (call run.user_run_file_type_transition_file (subj))
+
+       (call tmp.manage_file_sock_files (subj))
+       (call tmp.tmp_file_type_transition_file (subj))
+
+       (call tmpfs.manage_file_files (subj))
+       (call tmpfs.map_file_files (subj))
+       (call tmpfs.tmp_fs_type_transition_file (subj))
+
+       (call .cpu.read_sysfile_files (subj))
+       (call .cpu.search_sysfile_pattern.type (subj))
+
+       (call .font.cache.dontaudit_setattr_file.type (subj))
+       (call .font.cache.map_file_pattern.type (subj))
+       (call .font.cache.read_file_pattern.type (subj))
+       (call .font.conf.read_file_pattern.type (subj))
+       (call .font.data.map_file_pattern.type (subj))
+       (call .font.data.read_file_pattern.type (subj))
+
+       (call .font.home.cache.manage_file_pattern.type (subj))
+       (call .font.home.cache.map_file_pattern.type (subj))
+       (call .font.home.conf.read_file_pattern.type (subj))
+       (call .font.home.data.map_file_pattern.type (subj))
+       (call .font.home.data.read_file_pattern.type (subj))
+
+;;       (call .icons.data.read_file_pattern.type (subj))
+
+       (call .libnotify.send.subj_type_transition (subj))
+
+       (call .locale.data.map_file_pattern.type (subj))
+       (call .locale.read_file_pattern.type (subj))
+
+       (call .nss.passwdgroup.type (subj))
+
+;;       (call .pixmaps.data.read_file_pattern.type (subj))
+
+       (call .ptmx.readwrite_nodedev_chr_files (subj))
+
+       (call .shells.read_file_files (subj))
+
+       (call .subj.interactivefd.type (subj))
+
+       (call .systemd.journal.relay_msgs.type (subj))
+
+       (call .tmp.deletename_file_dirs (subj))
+
+       (call .user.devpts_fs_type_transition_ptytermdev (subj))
+
+       (call .user.exec_subj_type_transition (subj))
+       (call .user.exec_home_subj_type_transition (subj))
+
+       (call .user.home.list_file_dirs (subj))
+
+       (call .user.home.conf.list_file_dirs (subj))
+
+       (call .user.readwrite_ptytermdev_chr_files (subj))
+
+       (call .user.run.deletename_file_dirs (subj))
+
+       (call .user.shell_exec_subj_type_transition (subj))
+
+       (call .user.systemd.agent (subj exec.file))
+
+       (call .wlroots.client.type (subj))
+
+       (call .xattr.getattr_fs_pattern.type (subj))
+
+;;       (call .xkb.data.map_file_pattern.type (subj))
+;;       (call .xkb.data.read_file_pattern.type (subj))
+
+       (optional foot_waypipe
+		 (call .waypipe.agent (subj exec.file)))
+
+       (block client
+
+	      (blockinherit .user.agent.template)
+
+	      (allow subj self create_unix_stream_socket)
+
+	      (call unix_stream_connect (subj))
+
+	      (call .user.run.search_file_pattern.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/footclient" file file_context)))
+
+       (block exec
+
+	      (filecon "/usr/bin/foot" file file_context))
+
+       (block home
+
+	      (block conf
+
+		     (filecon "HOME_DIR/\.config/foot" dir file_context)
+		     (filecon "HOME_DIR/\.config/foot/.*" any file_context)
+
+		     (macro user_home_conf_file_type_transition_file
+			    ((type ARG1))
+			    (call .user.home.conf.file_type_transition
+				  (ARG1 file dir "foot")))
+
+		     (blockinherit .file.user.home.conf.template)))
+
+       (block run
+
+	      (filecon "/run/user/%{USERID}/foot-wayland-([1-9]+)?\.sock" socket
+		       file_context)
+
+	      (macro user_run_file_type_transition_file ((type ARG1))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "foot-wayland-1.sock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "foot-wayland-2.sock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "foot-wayland-3.sock")))
+
+	      (blockinherit .file.macro_template_sock_files)
+	      (blockinherit .file.user.run.base_template))
+
+       (block tmp
+
+	      (macro tmp_file_type_transition_file ((type ARG1))
+		     (call .tmp.file_type_transition
+			   (ARG1 file sock_file "*")))
+
+	      (blockinherit .file.macro_template_sock_files)
+	      (blockinherit .file.user.tmp.base_template))
+
+       (block tmpfs
+
+	      (macro map_file_files ((type ARG1))
+		     (allow ARG1 file (file (map))))
+
+	      (macro tmp_fs_type_transition_file ((type ARG1))
+		     (call .tmp.fs_type_transition
+			   (ARG1 file file "*")))
+
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.user.tmpfs.base_template)
+
+	      (call .wlroots.client.tmpfs.type (file))))
+
+(in file.unconfined
+
+    (call .foot.home.conf.user_home_conf_file_type_transition_file (typeattr))
+    (call .foot.run.user_run_file_type_transition_file (typeattr)))
+
+(in user
+
+    (call .foot.client.role (role))
+    (call .foot.home.conf.manage_file_dirs (subj))
+    (call .foot.home.conf.manage_file_files (subj))
+    (call .foot.home.conf.manage_file_lnk_files (subj))
+    (call .foot.home.conf.relabel_file_dirs (subj))
+    (call .foot.home.conf.relabel_file_files (subj))
+    (call .foot.home.conf.relabel_file_lnk_files (subj))
+    (call .foot.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call .foot.role (role))
+    (call .foot.run.manage_file_sock_files (subj))
+    (call .foot.run.relabel_file_sock_files (subj))
+    (call .foot.run.user_run_file_type_transition_file (subj))
+    (call .foot.tmp.manage_file_sock_files (subj))
+    (call .foot.tmp.relabel_file_sock_files (subj))
+    (call .foot.tmpfs.manage_file_files (subj))
+    (call .foot.tmpfs.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .foot.client.role (role))
+    (call .foot.role (role)))

--- a/src/agent/useragent/s/sway.cil
+++ b/src/agent/useragent/s/sway.cil
@@ -1,0 +1,443 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block sway
+
+       (macro unix_stream_connect ((type ARG1))
+	      (call connectto_subj_unix_stream_sockets (ARG1))
+	      (call run.write_file_sock_files (ARG1)))
+
+       (blockinherit .dbus.client.template)
+       (blockinherit .user.agent.template)
+
+       (allow subj self (process (getcap getsched setcap setpgid setsched)))
+       (allow subj self create_netlink_kobject_uevent_socket)
+       (allow subj self (unix_stream_socket (accept connectto listen)))
+
+       (call bar.noatsecure_subj_processes (subj))
+       (call bar.role (roleattr))
+       (call bar.signal_subj_processes (subj))
+       (call bar.subj_type_transition (subj))
+
+       (call client.run.map_file_files (subj))
+       (call client.run.readwriteinherited_file_files (subj))
+       (call client.use_all_fds (subj))
+
+       (call conf.list_file_dirs (subj))
+       (call conf.read_file_files (subj))
+
+       (call home.conf.list_file_dirs (subj))
+       (call home.conf.read_file_files (subj))
+
+       (call run.manage_file_sock_files (subj))
+       (call run.user_run_file_type_transition_file (subj))
+
+       (call tmpfs.manage_file_files (subj))
+       (call tmpfs.map_file_files (subj))
+       (call tmpfs.tmp_fs_type_transition_file (subj))
+
+;;       (call .backgrounds.data.search_file_dirs (subj))
+
+       (call .bus.list_sysfile_dirs (subj))
+
+       (call .class.list_sysfile_dirs (subj))
+       (call .class.read_sysfile_lnk_files (subj))
+
+       (call .cpu.read_sysfile_pattern.type (subj))
+
+       (call .cpuinfo.read_procfile_files (subj))
+
+       (call .crypto.read_sysctlfile_pattern.type (subj))
+
+       (call .dev.list_file_pattern.type (subj))
+
+       (call .dev.read_sysctlfile_pattern.type (subj))
+
+       (call .dev.traverse_sysfile_pattern.type (subj))
+
+       (call .devices.read_sysfile_pattern.type (subj))
+
+       (call .dri.map_nodedev_pattern.type (subj))
+       (call .dri.readwrite_nodedev_pattern.type (subj))
+
+       (call .event.readwriteinherited_nodedev_chr_files (subj))
+
+       (call .firmware.search_sysfile_pattern.type (subj))
+
+       (call .font.cache.dontaudit_setattr_file.type (subj))
+       (call .font.cache.map_file_pattern.type (subj))
+       (call .font.cache.read_file_pattern.type (subj))
+       (call .font.conf.read_file_pattern.type (subj))
+       (call .font.data.map_file_pattern.type (subj))
+       (call .font.data.read_file_pattern.type (subj))
+
+       (call .font.home.cache.manage_file_pattern.type (subj))
+       (call .font.home.cache.map_file_pattern.type (subj))
+       (call .font.home.conf.read_file_pattern.type (subj))
+       (call .font.home.data.map_file_pattern.type (subj))
+       (call .font.home.data.read_file_pattern.type (subj))
+
+;;       (call .icons.data.read_file_pattern.type (subj))
+
+;;       (call .libdrm.data.read_file_pattern.type (subj))
+
+;;       (call .libglvnd.read_file_pattern.type (subj))
+
+;;       (call .libinput.data.list_file_dirs (subj))
+;;       (call .libinput.data.read_file_files (subj))
+
+;;       (call .mesa.data.read_file_pattern.type (subj))
+
+;;       (call .mesa.home.cache.manage_file_pattern.type (subj))
+;;       (call .mesa.home.cache.map_file_pattern.type (subj))
+
+       (call .modules.read_procfile_pattern.type (subj))
+
+       (call .nss.passwdgroup.type (subj))
+
+       (call .overcommitmemory.read_sysctlfile_pattern.type (subj))
+
+;;       (call .pixmaps.data.read_file_pattern.type (subj))
+
+       (call .random.read_nodedev_chr_files (subj))
+
+       (call .selinux.conf.read_file_files (subj))
+       (call .selinux.linked.type (subj))
+       (call .selinux.search_fs_pattern.type (subj))
+
+       (call .systemd.login.sendmsg_subj_dbus.type (subj))
+
+       (call .systemd.seats.run.list_file_dirs (subj))
+       (call .systemd.seats.run.read_file_files (subj))
+
+       (call .systemd.sessions.run.list_file_dirs (subj))
+       (call .systemd.sessions.run.read_file_files (subj))
+
+       (call .systemd.udev.run.read_file_pattern.type (subj))
+
+       (call .tmp.getattr_fs_pattern.type (subj))
+
+       (call .user.shell_exec_subj_type_transition (subj))
+
+       (call .user.systemd.agent (subj exec.file))
+
+       (call .user.unpriv.read_all_states (subj))
+
+       (call .wlroots.compositor.type (subj))
+
+       (call .xattr.getattr_fs_pattern.type (subj))
+
+;;       (call .xkb.data.map_file_pattern.type (subj))
+;;       (call .xkb.data.read_file_pattern.type (subj))
+
+       (block bar
+
+	      (blockinherit .user.agent.template)
+	      (blockinherit .user.dbus.nameclient.template)
+
+	      (allow subj self (process (getsched setsched)))
+	      (allow subj self create_unix_stream_socket)
+
+	      (call sendmsg_subj_dbus.type (subj))
+
+	      (call tmpfs.manage_file_files (subj))
+	      (call tmpfs.map_file_files (subj))
+	      (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	      (call sway.client.read_all_states (subj))
+	      (call sway.client.type (subj))
+
+	      (call sway.run.write_file_sock_files (subj))
+
+	      (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	      (call .font.cache.dontaudit_setattr_file.type (subj))
+	      (call .font.cache.map_file_pattern.type (subj))
+	      (call .font.cache.read_file_pattern.type (subj))
+	      (call .font.conf.read_file_pattern.type (subj))
+	      (call .font.data.map_file_pattern.type (subj))
+	      (call .font.data.read_file_pattern.type (subj))
+
+	      (call .font.home.cache.manage_file_pattern.type (subj))
+	      (call .font.home.cache.map_file_pattern.type (subj))
+	      (call .font.home.conf.read_file_pattern.type (subj))
+	      (call .font.home.data.map_file_pattern.type (subj))
+	      (call .font.home.data.read_file_pattern.type (subj))
+
+;;	      (call .icons.data.read_file_pattern.type (subj))
+
+;;	      (call .mesa.home.cache.manage_file_pattern.type (subj))
+;;	      (call .mesa.home.cache.map_file_pattern.type (subj))
+
+;;	      (call .pixmaps.data.read_file_pattern.type (subj))
+
+	      (call .random.read_nodedev_chr_files (subj))
+
+	      (call .selinux.linked.type (subj))
+
+	      (call .user.signal_subj_processes (subj))
+
+	      (call .user.shell_exec_subj_type_transition (subj))
+
+	      (call .wlroots.client.type (subj))
+
+	      (call .xattr.getattr_fs_pattern.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/swaybar" file file_context))
+
+	      (block tmpfs
+
+		     (macro map_file_files ((type ARG1))
+			    (allow ARG1 file (file (map))))
+
+		     (macro tmp_fs_type_transition_file ((type ARG1))
+			    (call .tmp.fs_type_transition
+				  (ARG1 file file "*")))
+
+		     (blockinherit .file.macro_template_files)
+		     (blockinherit .file.user.tmpfs.base_template)
+
+		     (call .wlroots.client.tmpfs.type (file))))
+
+       (block client
+
+	      (macro read_all_states ((type ARG1))
+		     (allow ARG1 typeattr (state (read))))
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (macro use_all_fds ((type ARG1))
+		     (allow ARG1 typeattr (fd (use))))
+
+	      (typeattribute typeattr)
+
+	      (call run.manage_file_files (typeattr))
+	      (call run.map_file_files (typeattr))
+	      (call run.user_run_file_type_transition_file (typeattr))
+
+	      ;; probably leaks
+	      ;; (call sway.conf.readinherited_file_files (typeattr))
+	      ;; (call sway.home.conf.readinherited_file_files (typeattr))
+	      (call sway.readinherited_subj_fifo_files (typeattr))
+	      (call sway.readwrite_subj_unix_stream_sockets (typeattr))
+	      (call sway.use_subj_fds (typeattr))
+
+	      (call .runuser.search_file_pattern.type (typeattr))
+
+	      (call .user.run.deletename_file_dirs (typeattr))
+
+	      (block run
+
+		     (macro manage_file_files ((type ARG1))
+			    (allow ARG1 file manage_file))
+
+		     (macro map_file_files ((type ARG1))
+			    (allow ARG1 file (file (map))))
+
+		     (macro user_run_file_type_transition_file ((type ARG1))
+			    (call .user.run.file_type_transition
+				  (ARG1 file file "*")))
+
+		     (blockinherit .file.macro_template_files)
+		     (blockinherit .file.user.run.base_template)))
+
+       (block conf
+
+	      (filecon "/etc/sway" dir file_context)
+	      (filecon "/etc/sway/.*" any file_context)
+
+	      (macro conf_file_type_transition_file ((type ARG1))
+		     (call .conf.file_type_transition
+			   (ARG1 file dir "sway")))
+
+	      (macro dontaudit_readinherited_file_files ((type ARG1))
+		     (dontaudit ARG1 file readinherited_file))
+
+	      (macro readinherited_file_files ((type ARG1))
+		     (allow ARG1 file readinherited_file))
+
+	      (blockinherit .file.conf.template))
+
+       (block exec
+
+	      (filecon "/usr/bin/sway" file file_context))
+
+       (block home
+
+	      (block conf
+
+		     (filecon "HOME_DIR/\.config/sway" dir file_context)
+		     (filecon "HOME_DIR/\.config/sway/.*" any file_context)
+
+		     (macro map_file_files ((type ARG1))
+			    (allow ARG1 file (file (map))))
+
+		     (macro readinherited_file_files ((type ARG1))
+			    (allow ARG1 file readinherited_file))
+
+		     (macro user_home_conf_file_type_transition_file
+			    ((type ARG1))
+			    (call .user.home.conf.file_type_transition
+				  (ARG1 file dir "sway")))
+
+		     (blockinherit .file.user.home.conf.template)))
+
+       (block msg
+
+	      (blockinherit .user.agent.template)
+
+	      (allow subj self create_unix_stream_socket)
+
+	      (call sway.unix_stream_connect (subj))
+
+	      (call sway.exec.execute_file_files (subj))
+
+	      (call sway.client.type (subj))
+
+	      (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	      (call .locale.data.map_file_pattern.type (subj))
+	      (call .locale.read_file_pattern.type (subj))
+
+	      (call .random.read_nodedev_chr_files (subj))
+
+	      (call .selinux.linked.type (subj))
+
+	      (call .shell.exec.execute_file_files (subj))
+
+	      (call .terminfo.read_file_pattern.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/swaymsg" file file_context)))
+
+       (block nag
+
+	      (blockinherit .user.agent.template)
+
+	      (allow subj self (process (getsched setsched)))
+	      (allow subj self create_unix_stream_socket)
+
+	      (call tmpfs.manage_file_files (subj))
+	      (call tmpfs.map_file_files (subj))
+	      (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	      (call sway.client.type (subj))
+
+	      (call sway.msg.role (roleattr))
+	      (call sway.msg.signal_subj_processes (subj))
+	      (call sway.msg.subj_type_transition (subj))
+
+	      (call .font.cache.dontaudit_setattr_file.type (subj))
+	      (call .font.cache.map_file_pattern.type (subj))
+	      (call .font.cache.read_file_pattern.type (subj))
+	      (call .font.conf.read_file_pattern.type (subj))
+	      (call .font.data.map_file_pattern.type (subj))
+	      (call .font.data.read_file_pattern.type (subj))
+
+	      (call .font.home.cache.manage_file_pattern.type (subj))
+	      (call .font.home.cache.map_file_pattern.type (subj))
+	      (call .font.home.conf.read_file_pattern.type (subj))
+	      (call .font.home.data.map_file_pattern.type (subj))
+	      (call .font.home.data.read_file_pattern.type (subj))
+
+;;	      (call .icons.data.read_file_pattern.type (subj))
+
+;;	      (call .mesa.home.cache.manage_file_pattern.type (subj))
+;;	      (call .mesa.home.cache.map_file_pattern.type (subj))
+
+;;	      (call .pixmaps.data.read_file_pattern.type (subj))
+
+	      (call .selinux.linked.type (subj))
+
+	      (call .user.shell_exec_subj_type_transition (subj))
+
+	      (call .wlroots.client.type (subj))
+
+	      (call .xattr.getattr_fs_pattern.type (subj))
+
+	      (block exec
+
+		     (filecon "/usr/bin/swaynag" file file_context))
+
+	      (block tmpfs
+
+		     (macro map_file_files ((type ARG1))
+			    (allow ARG1 file (file (map))))
+
+		     (macro tmp_fs_type_transition_file ((type ARG1))
+			    (call .tmp.fs_type_transition
+				  (ARG1 file file "*")))
+
+		     (blockinherit .file.macro_template_files)
+		     (blockinherit .file.user.tmpfs.base_template)
+
+		     (call .wlroots.client.tmpfs.type (file))))
+
+       (block run
+
+	      (filecon "/run/user/%{USERID}/sway-ipc\..*\.sock" socket
+		       file_context)
+
+	      (macro user_run_file_type_transition_file ((type ARG1))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "*")))
+
+	      (blockinherit .file.macro_template_sock_files)
+	      (blockinherit .file.user.run.base_template))
+
+       (block tmpfs
+
+	      (macro map_file_files ((type ARG1))
+		     (allow ARG1 file (file (map))))
+
+	      (macro tmp_fs_type_transition_file ((type ARG1))
+		     (call .tmp.fs_type_transition
+			   (ARG1 file file "*")))
+
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.user.tmpfs.base_template)
+
+	      (call .wlroots.compositor.tmpfs.type (file))))
+
+(in file.unconfined
+
+    (call .sway.conf.conf_file_type_transition_file (typeattr))
+    (call .sway.home.conf.user_home_conf_file_type_transition_file (typeattr)))
+
+(in systemd.login
+
+    (call .sway.sendmsg_subj_dbus.type (subj)))
+
+(in user
+
+    (call .sway.bar.noatsecure_subj_processes (subj))
+    (call .sway.bar.readwrite_subj_unix_stream_sockets (subj))
+    (call .sway.bar.tmpfs.manage_file_files (subj))
+    (call .sway.bar.tmpfs.relabel_file_files (subj))
+    (call .sway.client.run.manage_file_files (subj))
+    (call .sway.client.run.relabel_file_files (subj))
+    (call .sway.conf.dontaudit_readinherited_file_files (subj))
+    (call .sway.home.conf.manage_file_dirs (subj))
+    (call .sway.home.conf.manage_file_files (subj))
+    (call .sway.home.conf.map_file_files (subj))
+    (call .sway.home.conf.relabel_file_dirs (subj))
+    (call .sway.home.conf.relabel_file_files (subj))
+    (call .sway.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call .sway.nag.role (role))
+    (call .sway.nag.tmpfs.manage_file_files (subj))
+    (call .sway.nag.tmpfs.relabel_file_files (subj))
+    (call .sway.readwrite_subj_unix_stream_sockets (subj))
+    (call .sway.role (role))
+    (call .sway.run.manage_file_sock_files (subj))
+    (call .sway.run.relabel_file_sock_files (subj))
+    (call .sway.tmpfs.manage_file_files (subj))
+    (call .sway.tmpfs.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .sway.nag.role (role))
+    (call .sway.role (role)))

--- a/src/agent/useragent/s/swaybg.cil
+++ b/src/agent/useragent/s/swaybg.cil
@@ -1,0 +1,61 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in sway
+
+    (block bg
+
+	   (blockinherit .user.agent.template)
+
+	   (call tmpfs.manage_file_files (subj))
+	   (call tmpfs.map_file_files (subj))
+	   (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	   (call sway.client.type (subj))
+
+;;	   (call .backgrounds.data.read_file_files (subj))
+;;	   (call .backgrounds.data.search_file_dirs (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .mime.data.map_file_pattern.type (subj))
+	   (call .mime.read_file_pattern.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .user.home.read_file_files (subj))
+
+	   (call .wlroots.client.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/swaybg" file file_context))
+
+	   (block tmpfs
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro tmp_fs_type_transition_file ((type ARG1))
+			 (call .tmp.fs_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.user.tmpfs.base_template)
+
+		  (call .wlroots.client.tmpfs.type (file)))))
+
+(in sway
+
+    (call bg.subj_type_transition (subj)))
+
+(in user
+
+    (call .sway.bg.role (role))
+    (call .sway.bg.tmpfs.manage_file_files (subj))
+    (call .sway.bg.tmpfs.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .sway.bg.role (role)))

--- a/src/agent/useragent/s/swayidle.cil
+++ b/src/agent/useragent/s/swayidle.cil
@@ -1,0 +1,87 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .sway.idle.conf.conf_file_type_transition_file (typeattr))
+    (call .sway.idle.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr)))
+
+(in sway
+
+    (block idle
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .user.agent.template)
+
+	   (allow subj self create_unix_stream_socket)
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call home.conf.list_file_dirs (subj))
+	   (call home.conf.read_file_files (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .selinux.linked.type (subj))
+
+	   (call .systemd.login.inhibit.type (subj))
+	   (call .systemd.login.sendmsg_subj_dbus.type (subj))
+
+	   (call .user.home.conf.search_file_pattern.type (subj))
+
+	   (call .user.shell_exec_subj_type_transition (subj))
+
+	   (call .wlroots.client.type (subj))
+
+	   (block conf
+
+		  (filecon "/etc/swayidle" dir file_context)
+		  (filecon "/etc/swayidle/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "swayidle")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block exec
+
+		  (filecon "/usr/bin/swayidle" file file_context))
+
+	   (block home
+
+		  (block conf
+
+			 (filecon "HOME_DIR/\.config/swayidle" dir file_context)
+			 (filecon "HOME_DIR/\.config/swayidle/.*" any
+				  file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_conf_file_type_transition_file
+				((type ARG1))
+				(call .user.home.conf.file_type_transition
+				      (ARG1 file dir "swayidle")))
+
+			 (blockinherit .file.user.home.conf.template)))))
+
+(in systemd.login
+
+    (call .sway.idle.sendmsg_subj_dbus.type (subj)))
+
+(in user
+
+    (call .sway.idle.home.conf.manage_file_dirs (subj))
+    (call .sway.idle.home.conf.manage_file_files (subj))
+    (call .sway.idle.home.conf.map_file_files (subj))
+    (call .sway.idle.home.conf.relabel_file_dirs (subj))
+    (call .sway.idle.home.conf.relabel_file_files (subj))
+    (call .sway.idle.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call .sway.idle.role (role)))
+
+(in wheel
+
+    (call .sway.idle.role (role)))

--- a/src/agent/useragent/s/swaylock.cil
+++ b/src/agent/useragent/s/swaylock.cil
@@ -1,0 +1,136 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in file.unconfined
+
+    (call .sway.lock.conf.conf_file_type_transition_file (typeattr))
+    (call .sway.lock.home.conf.user_home_conf_file_type_transition_file
+	  (typeattr)))
+
+(in sway
+
+    (block lock
+
+	   (blockinherit .dbus.client.template)
+	   (blockinherit .user.agent.template)
+
+	   (allow subj self (process (getcap)))
+	   (allow subj self create_netlink_audit_socket)
+	   (allow subj self create_unix_dgram_socket)
+	   (allow subj self (netlink_audit_socket (nlmsg_relay)))
+
+	   (call conf.list_file_dirs (subj))
+	   (call conf.read_file_files (subj))
+
+	   (call home.conf.list_file_dirs (subj))
+	   (call home.conf.read_file_files (subj))
+
+	   (call sway.client.type (subj))
+
+	   (call tmpfs.manage_file_files (subj))
+	   (call tmpfs.map_file_files (subj))
+	   (call tmpfs.tmp_fs_type_transition_file (subj))
+
+	   (call .caplastcap.read_sysctlfile_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .dev.list_file_pattern.type (subj))
+
+	   (call .devpts.search_fs_pattern.type (subj))
+
+	   (call .font.cache.dontaudit_setattr_file.type (subj))
+	   (call .font.cache.map_file_pattern.type (subj))
+	   (call .font.cache.read_file_pattern.type (subj))
+	   (call .font.conf.read_file_pattern.type (subj))
+	   (call .font.data.map_file_pattern.type (subj))
+	   (call .font.data.read_file_pattern.type (subj))
+
+	   (call .font.home.cache.map_file_pattern.type (subj))
+	   (call .font.home.cache.manage_file_pattern.type (subj))
+	   (call .font.home.cache.user_home_cache_file_type_transition_file
+		 (subj))
+	   (call .font.home.conf.read_file_pattern.type (subj))
+	   (call .font.home.data.map_file_pattern.type (subj))
+	   (call .font.home.data.read_file_pattern.type (subj))
+
+	   (call .locale.data.map_file_pattern.type (subj))
+	   (call .locale.read_file_pattern.type (subj))
+
+	   (call .nss.passwdgroup.type (subj))
+
+	   (call .pam.linked.type (subj))
+
+	   (call .proc.getattr_fs_pattern.type (subj))
+
+	   (call .systemd.journal.relay_msgs.type (subj))
+
+	   (call .wlroots.client.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+;;	   (call .xkb.data.map_file_pattern.type (subj))
+;;	   (call .xkb.data.read_file_pattern.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/swaylock" file file_context))
+
+	   (block conf
+
+		  (filecon "/etc/swaylock" dir file_context)
+		  (filecon "/etc/swaylock/.*" any file_context)
+
+		  (macro conf_file_type_transition_file ((type ARG1))
+			 (call .conf.file_type_transition
+			       (ARG1 file dir "swaylock")))
+
+		  (blockinherit .file.conf.template))
+
+	   (block home
+
+		  (block conf
+
+			 (filecon "HOME_DIR/\.config/swaylock" dir file_context)
+			 (filecon "HOME_DIR/\.config/swaylock/.*" any
+				  file_context)
+
+			 (macro map_file_files ((type ARG1))
+				(allow ARG1 file (file (map))))
+
+			 (macro user_home_conf_file_type_transition_file
+				((type ARG1))
+				(call .user.home.conf.file_type_transition
+				      (ARG1 file dir "swaylock")))
+
+			 (blockinherit .file.user.home.conf.template)))
+
+	   (block tmpfs
+
+		  (macro map_file_files ((type ARG1))
+			 (allow ARG1 file (file (map))))
+
+		  (macro tmp_fs_type_transition_file ((type ARG1))
+			 (call .tmp.fs_type_transition
+			       (ARG1 file file "*")))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.user.tmpfs.base_template)
+
+		  (call .wlroots.client.tmpfs.type (file)))))
+
+(in user
+
+    (call .sway.lock.home.conf.manage_file_dirs (subj))
+    (call .sway.lock.home.conf.manage_file_files (subj))
+    (call .sway.lock.home.conf.map_file_files (subj))
+    (call .sway.lock.home.conf.relabel_file_dirs (subj))
+    (call .sway.lock.home.conf.relabel_file_files (subj))
+    (call .sway.lock.home.conf.user_home_conf_file_type_transition_file (subj))
+    (call .sway.lock.role (role))
+    (call .sway.lock.tmpfs.manage_file_files (subj))
+    (call .sway.lock.tmpfs.relabel_file_files (subj)))
+
+(in wheel
+
+    (call .sway.lock.role (role)))

--- a/src/file/userfile/userrunuserfile/waylanduserrunfile.cil
+++ b/src/file/userfile/userrunuserfile/waylanduserrunfile.cil
@@ -1,0 +1,41 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block wayland
+
+       (block run
+
+	      (filecon "/run/user/%{USERID}/wayland-([1-9]+)?" socket
+		       file_context)
+	      (filecon "/run/user/%{USERID}/wayland-([1-9]+)?\.lock" file
+		       file_context)
+
+	      (macro user_run_file_type_transition_file ((type ARG1))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "wayland-1.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "wayland-2.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file file "wayland-3.lock"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "wayland-1"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "wayland-2"))
+		     (call .user.run.file_type_transition
+			   (ARG1 file sock_file "wayland-3")))
+
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.macro_template_sock_files)
+	      (blockinherit .file.user.run.base_template)))
+
+(in file.unconfined
+
+    (call .wayland.run.user_run_file_type_transition_file (typeattr)))
+
+(in user
+
+    (call .wayland.run.manage_file_files (subj))
+    (call .wayland.run.manage_file_sock_files (subj))
+    (call .wayland.run.relabel_file_files (subj))
+    (call .wayland.run.relabel_file_sock_files (subj))
+    (call .wayland.run.user_run_file_type_transition_file (subj)))


### PR DESCRIPTION
- agent minor style
- reprepro fix
- probably best to not get into this now
- polkit is glib2.gio linked
- adds vlock
- allow pam.linked to read pam data files
- allows unlabeled to associate with xattr.fs
- glib2.gio.linked lists the modules dir (polkit)
- udev: must be related to apparmor
- initramfstools: blkid reads initramfstools /proc/pid/mounts
- initramfs: cryptroot access to /sys/fs/btrfs
- mpd system instance
- adds btrfsprogs
- adds groupadd and useradd
- groupadd useradd rules
- mpd fixes typo
- adds sway, foot and some of their depdendencies
