### PR TITLE
sway

### DIFF
--- a/src/agent/useragent/f/firefox.cil
+++ b/src/agent/useragent/f/firefox.cil
@@ -261,6 +261,12 @@
        (call .xdg.conf.read_file_files (subj))
        (call .xdg.conf.watch_file_dirs (subj))
 
+       (optional firefox_foot
+		 (call .foot.subj_type_transition (subj)))
+
+       (optional firefox_mpc
+		 (call .mpd.ncmpc.exec.auditexecuteaccess_file_files (subj)))
+
        (optional firefox_p11kit
 		 (call .p11kit.conf.read_file_pattern.type (subj))
 		 (call .p11kit.data.map_file_files (subj))

--- a/src/agent/useragent/m/mpc.cil
+++ b/src/agent/useragent/m/mpc.cil
@@ -97,6 +97,9 @@
 
 	   (block exec
 
+		  (macro auditexecuteaccess_file_files ((type ARG1))
+			 (allow ARG1 file (file (execute getattr))))
+
 		  (filecon "/usr/bin/mpc" file file_context)
 		  (filecon "/usr/bin/ncmpc" file file_context))
 


### PR DESCRIPTION
- systemd-hwdb looks into /etc/udev/hwdb.d
- sway related
- sway again
- adds dbus update environment
- foot dbusupdateenv and x11usertmpfile
- adds mako
- gtk and firefox
- firefox
- gtk icon cache
- firefox related and loose ends
- firefox
- firefox loose ends
- firefox related to making it default browser
- firefox applications
