### PR TITLE
dssp5-debian does not support monolithic policy

### DIFF
--- a/src/net/netifnet.cil
+++ b/src/net/netifnet.cil
@@ -15,7 +15,7 @@
 (macro ingress_invalid_netifs ((type ARG1))
        (allow ARG1 invalid (netif (ingress))))
 
-(tunableif (or invalid_associations invalid_peers)
+(booleanif (or invalid_associations invalid_peers)
 	   (true
 
 	    (call net.netif.egressingress_all_netifs (invalid))))

--- a/src/net/nodenet.cil
+++ b/src/net/nodenet.cil
@@ -15,7 +15,7 @@
 (macro sendto_invalid_nodes ((type ARG1))
        (allow ARG1 invalid (node (sendto))))
 
-(tunableif (or invalid_associations invalid_peers)
+(booleanif (or invalid_associations invalid_peers)
 	   (true
 
 	    (call net.netnode.recvfromsendto_all_nodes (invalid))))

--- a/src/net/packetnet.cil
+++ b/src/net/packetnet.cil
@@ -25,13 +25,13 @@
 (macro send_invalid_packets ((type ARG1))
        (allow ARG1 invalid (packet (send))))
 
-(tunableif invalid_packets
+(booleanif invalid_packets
 	   (true
 
 	    (call forward_invalid_packets (invalidpackets.except.typeattr))
 	    (call recvsend_invalid_packets (invalidpackets.except.typeattr))))
 
-(tunableif (or invalid_associations invalid_peers)
+(booleanif (or invalid_associations invalid_peers)
 	   (true
 
 	    (call forward_invalid_packets (invalid))

--- a/src/net/peernet.cil
+++ b/src/net/peernet.cil
@@ -9,7 +9,7 @@
 (macro recv_invalid_peers ((type ARG1))
        (allow ARG1 invalid (peer (recv))))
 
-(tunableif invalid_peers
+(booleanif invalid_peers
 	   (true
 
 	    (call association_invalid_sctp_sockets

--- a/src/net/spdnet.cil
+++ b/src/net/spdnet.cil
@@ -22,7 +22,7 @@
 (macro setcontext_invalid_associations ((type ARG1))
        (allow ARG1 invalid (association (setcontext))))
 
-(tunableif invalid_associations
+(booleanif invalid_associations
 	   (true
 
 	    (call association_invalid_sctp_sockets

--- a/src/selinux/booleanfile/invalidassociationsbooleanfile.cil
+++ b/src/selinux/booleanfile/invalidassociationsbooleanfile.cil
@@ -1,7 +1,7 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
-(tunable invalid_associations true)
+(boolean invalid_associations true)
 
 (block invalid_associations
 

--- a/src/selinux/booleanfile/invalidpacketsbooleanfile.cil
+++ b/src/selinux/booleanfile/invalidpacketsbooleanfile.cil
@@ -1,7 +1,7 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
-(tunable invalid_packets true)
+(boolean invalid_packets true)
 
 (block invalid_packets
 

--- a/src/selinux/booleanfile/invalidpeersbooleanfile.cil
+++ b/src/selinux/booleanfile/invalidpeersbooleanfile.cil
@@ -1,7 +1,7 @@
 ;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
 ;; SPDX-License-Identifier: Unlicense
 
-(tunable invalid_peers true)
+(boolean invalid_peers true)
 
 (block invalid_peers
 


### PR DESCRIPTION
no point in using tunables here

except for xserver_object_manager which is effectively unconditional anyway
