### PR TITLE
dssp5 debian

### DIFF
--- a/src/agent/misc/apache/apachesuexec.cil
+++ b/src/agent/misc/apache/apachesuexec.cil
@@ -14,6 +14,7 @@
 	   (call log.create_file_files (subj))
 	   (call log.apache_log_file_type_transition_file (subj))
 
+	   (call apache.log.append_file_files (subj))
 	   (call apache.server.readwrite_subj_unix_stream_sockets (subj))
 
 	   (call .crypto.read_sysctlfile_pattern.type (subj))


### PR DESCRIPTION
- systemd-hwdb looks into /etc/udev/hwdb.d
- sway related
- sway again
- adds dbus update environment
- foot dbusupdateenv and x11usertmpfile
- adds mako
- gtk and firefox
- firefox
- gtk icon cache
- firefox related and loose ends
- firefox
- firefox loose ends
- firefox related to making it default browser
- firefox applications
- libinput glib firefox related
- loose ends
- mako and dbus
- systemd mount and systemd fsck
- unprivuser: override with custom macro
- adds pa-utils and brightlessctl
- fix opensshclient
- userdbus control user systemd runtime units
- adds slup grim wlrecorder waypipe wl clipboard
- grim slurp and wfrecorder rules
- adds qemu
- qemu-img rule
- dconf service
- dbus transient unit (mako)
- gh issue with nano
- dbus: for controlling dbus activated transient units
- remove waypipe and translate-shell: debian does not have it
- dssp5-debian does not support monolithic policy
- move from tunables to booleans
- pidoff gets attributes of /usr/lib/systemd/systemd in container
- contentfile and webcontentfile
- adds git content
- apache and related
- apachectl
- various apache
- apache suexec
