### PR TITLE
dssp5 debian

### DIFF
--- a/src/agent/misc/apache/apacheserver.cil
+++ b/src/agent/misc/apache/apacheserver.cil
@@ -91,6 +91,9 @@
 	   (optional apacheserver_certbot
 		     (call .certbot.conf.read_file_pattern.type (subj)))
 
+	   (optional apacheserver_gitsysfile
+		     (call .file.content.sys.git.search_all_dirs (subj)))
+
 	   (optional apacheserver_p11kit
 		     (call .p11kit.conf.read_file_pattern.type (subj))
 		     (call .p11kit.data.map_file_files (subj))

--- a/src/agent/useragent/g/gitclient.cil
+++ b/src/agent/useragent/g/gitclient.cil
@@ -102,6 +102,7 @@
 	   (call .fuse.getattr_fs_pattern.type (subj))
 	   (call .fuse.manage_fs_pattern.type (subj))
 
+	   (call .http.nameconnect_port_tcp_sockets (subj))
 	   (call .http.https.nameconnect_port_tcp_sockets (subj))
 
 	   (call .locale.data.map_file_pattern.type (subj))


### PR DESCRIPTION
- git sys htaccess is a web sys file
- git client: allow git clone http://
- apache traverses /var/lib/git
