### PR TITLE
dssp5 debian

### DIFF
--- a/src/agent/misc/mysql/mysqlserver.cil
+++ b/src/agent/misc/mysql/mysqlserver.cil
@@ -73,6 +73,8 @@
 
 	   (call .log.search_file_pattern.type (subj))
 
+	   (call .mcs.constrained.type (subj))
+
 	   (call .net.nodebind_netnode_tcp_sockets (subj))
 
 	   (call .ngroupsmax.read_sysctlfile_pattern.type (subj))

--- a/src/agent/misc/php/phpfpm.cil
+++ b/src/agent/misc/php/phpfpm.cil
@@ -368,6 +368,8 @@
 	   (call .locale.data.map_file_pattern.type (typeattr))
 	   (call .locale.read_file_pattern.type (typeattr))
 
+	   (call .mcs.constrained.type (typeattr))
+
 	   (call .ngroupsmax.read_sysctlfile_pattern.type (typeattr))
 
 	   (call .nss.passwdgroup.type (typeattr))


### PR DESCRIPTION
- mysql
- allow fstrim to get attr of unlabeled dirs
- mysql trim it a little bit
- adds rsync
- rsync
- make mysql server and phpfpm mcs constrained
