### PR TITLE
dssp5 debian

### DIFF
--- a/src/agent/hybridagent/s/sudo.cil
+++ b/src/agent/hybridagent/s/sudo.cil
@@ -190,6 +190,10 @@
     (optional sudo_opensshserver
 	      (call .openssh.server.unix_stream_connect (subj)))
 
+    (optional sudo_postfixsendmail
+	      (call .postfix.sendmail.mailer.type (subj))
+	      (call .postfix.sendmail.mailer.role (roleattr)))
+
     (optional sudo_systemdnspawn
 	      ;; sudo -r sys.role runcon -t systemd.nspawn.subj -- \
 	      ;; systemd-nspawn -Z sys.id:sys.role:systemd.nspawn.privcontainer.subj:s0 \

--- a/src/agent/misc/php/phpfpm.cil
+++ b/src/agent/misc/php/phpfpm.cil
@@ -300,7 +300,7 @@
     (optional phpfpm_mysqlunreservedport
 	      (call .mysql.nameconnect_port_tcp_sockets (subj)))
 
-    (optional phpfpm_postfix
+    (optional phpfpm_postfixsendmail
 	      (call .postfix.sendmail.mailer.type (subj))
 	      (call .postfix.sendmail.mailer.tmp.type (tmp.file)))
 

--- a/src/agent/misc/postfix.cil
+++ b/src/agent/misc/postfix.cil
@@ -1,0 +1,487 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block postfix
+
+       (blockinherit .sys.agent.template)
+
+       (allow subj self (capability (chown dac_read_search fowner)))
+       (allow subj self (tcp_socket (create)))
+
+       (call cli.signal_subj_processes (subj))
+       (call cli.subj_type_transition (subj))
+
+       (call common.exec.getattr_all_files (subj))
+       (call common.type (subj))
+
+;;       (call conf.setattr_file_dirs (subj))
+
+       (call log.manage_file_files (subj))
+       (call log.log_file_type_transition_file (subj "*"))
+
+       (call pid.spool.read_file_files (subj))
+
+       (call sendmail.exec.read_file_files (subj))
+
+       (call state.list_file_dirs (subj))
+       (call state.read_file_files (subj))
+;;       (call state.setattr_file_dirs (subj))
+
+       (call .cgroup.getattr_fs_pattern.type (subj))
+
+;;       (call .exec.dontaudit_setattr_file_dirs (subj))
+       (call .exec.execute_file_files (subj))
+       (call .exec.list_file_dirs (subj))
+
+       (call .file.spool.postfix.getattr_all_files (subj))
+       (call .file.spool.postfix.list_all_dirs (subj))
+       (call .file.spool.postfix.setattr_all_dirs (subj))
+
+       (call .log.deletename_file_dirs (subj))
+
+;;       (call .man.data.getattr_file_files (subj))
+;;       (call .man.data.search_file_dirs (subj))
+
+       (call .nss.hosts.type (subj))
+       (call .nss.passwdgroup.type (subj))
+
+       (call .osrelease.read_sysctlfile_pattern.type (subj))
+
+       (call .rbacsep.constrained.type (subj))
+       (call .rbacsep.usefdsource.type (subj))
+
+       (call .shell.exec.execute_file_files (subj))
+
+       (call .terminfo.conf.read_file_pattern.type (subj))
+       (call .terminfo.data.read_file_pattern.type (subj))
+
+       (call .xattr.getattr_fs_pattern.type (subj))
+
+       (block active
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/active" dir file_context)
+		     (filecon "/var/spool/postfix/active/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "active")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block bounce
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/bounce" dir file_context)
+		     (filecon "/var/spool/postfix/bounce/.*" any ())
+
+		     (macro getattr_file_files ((type ARG1))
+			    (allow ARG1 file (file (getattr))))
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "bounce")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block cert
+
+	      (filecon "/etc/ssl/postfix" dir file_context)
+	      (filecon "/etc/ssl/postfix/.*" any file_context)
+
+	      (macro cert_file_type_transition_file ((type ARG1))
+		     (call .cert.file_type_transition
+			   (ARG1 file dir "postfix")))
+
+	      (blockinherit .file.cert.template))
+
+       (block common
+
+	      (macro type ((type ARG1))
+		     (typeattributeset typeattr ARG1))
+
+	      (typeattribute typeattr)
+
+	      (allow typeattr self (process (getsched setrlimit setsched)))
+	      (allow typeattr self create_unix_dgram_socket)
+
+	      (call conf.list_file_dirs (typeattr))
+	      (call conf.read_file_files (typeattr))
+	      (call conf.read_file_lnk_files (typeattr))
+
+	      (call .cpu.read_sysfile_files (typeattr))
+	      (call .cpu.search_sysfile_pattern.type (typeattr))
+
+	      (call .crypto.read_sysctlfile_pattern.type (typeattr))
+
+	      (call .file.spool.postfix.search_all_dirs (typeattr))
+
+	      ;; is this ngroupsmax?
+	      (call .kernel.read_sysctlfile_pattern.type (typeattr))
+
+	      (call .locale.data.map_file_pattern.type (typeattr))
+	      (call .locale.read_file_pattern.type (typeattr))
+
+	      (call .net.read_procfile_pattern.type (typeattr))
+
+	      (call .random.read_sysctlfile_pattern.type (typeattr))
+
+	      (call .selinux.linked.type (typeattr))
+
+	      (call .spool.search_file_pattern.type (typeattr))
+
+	      (call .sys.agent.type (typeattr))
+
+	      (call .systemd.journal.relay_msgs.type (typeattr))
+
+	      (call .tmp.search_file_pattern.type (typeattr))
+
+	      (block exec
+
+		     (macro getattr_all_files ((type ARG1))
+			    (allow ARG1 typeattr (file (getattr))))
+
+		     (macro type ((type ARG1))
+			    (typeattributeset typeattr ARG1))
+
+		     (typeattribute typeattr)
+
+		     (call .sys.agent.exec.type (typeattr))))
+
+       (block conf
+
+	      (filecon "/etc/postfix" dir file_context)
+	      (filecon "/etc/postfix/.*" any file_context)
+
+	      (macro conf_file_type_transition_file ((type ARG1))
+		     (call .conf.file_type_transition
+			   (ARG1 file dir "postfix")))
+
+	      (blockinherit .file.conf.template))
+
+       (block corrupt
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/corrupt" dir file_context)
+		     (filecon "/var/spool/postfix/corrupt/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "corrupt")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block data
+
+	      (filecon "/usr/share/postfix" dir file_context)
+	      (filecon "/usr/share/postfix/.*" any file_context)
+
+	      (macro data_file_type_transition_file ((type ARG1))
+		     (call .data.file_type_transition
+			   (ARG1 file dir "postfix")))
+
+	      (blockinherit .file.data.base_template)
+	      (blockinherit .file.macro_template_dirs)
+	      (blockinherit .file.macro_template_files))
+
+       (block defer
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/defer" dir file_context)
+		     (filecon "/var/spool/postfix/defer/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "defer")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block deferred
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/deferred" dir file_context)
+		     (filecon "/var/spool/postfix/deferred/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "deferred")))
+
+		     (macro setattr_file_files ((type ARG1))
+			    (allow ARG1 file (file (setattr))))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block exec
+
+	      (filecon "/usr/bin/postfix" file file_context)
+	      (filecon "/usr/bin/postmulti" file file_context))
+
+       (block flush
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/flush" dir file_context)
+		     (filecon "/var/spool/postfix/flush/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "flush")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block hold
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/hold" dir file_context)
+		     (filecon "/var/spool/postfix/hold/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "hold")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block incoming
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/incoming" dir file_context)
+		     (filecon "/var/spool/postfix/incoming/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "incoming")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block log
+
+	      (filecon "/var/log/postfix\.log" file file_context)
+	      (filecon "/var/log/postfix\.log\..*" file file_context)
+
+	      (macro log_file_type_transition_file ((type ARG1)(name ARG2))
+		     (call .log.file_type_transition
+			   (ARG1 file file ARG2)))
+
+	      (blockinherit .file.log.template))
+
+       (block maildrop
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/maildrop" dir file_context)
+		     (filecon "/var/spool/postfix/maildrop/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "maildrop")))
+
+		     (blockinherit .file.spool.postfix.template)
+
+		     (call .rbacsep.exempt.obj.type (file))))
+
+       (block pid
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/pid" dir file_context)
+		     (filecon "/var/spool/postfix/pid/.*" any file_context)
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "pid")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block private
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/private" dir file_context)
+		     (filecon "/var/spool/postfix/private/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "private")))
+
+		     (blockinherit .file.macro_template_dirs)
+		     (blockinherit .file.macro_template_sock_files)
+		     (blockinherit .file.spool.postfix.base_template)))
+
+       (block public
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/public" dir file_context)
+		     (filecon "/var/spool/postfix/public/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "public")))
+
+		     (blockinherit .file.macro_template_dirs)
+		     (blockinherit .file.macro_template_sock_files)
+		     (blockinherit .file.spool.postfix.base_template)
+
+		     (call .rbacsep.exempt.obj.type (file))))
+
+       (block saved
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/saved" dir file_context)
+		     (filecon "/var/spool/postfix/saved/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "saved")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block spool
+
+	      (filecon "/var/spool/postfix" dir file_context)
+	      (filecon "/var/spool/postfix/.*" any file_context)
+
+	      (macro spool_file_type_transition_file ((type ARG1))
+		     (call .spool.file_type_transition
+			   (ARG1 file dir "postfix")))
+
+	      (blockinherit .file.spool.postfix.template))
+
+       (block state
+
+	      (filecon "/var/lib/misc/postfix\.aliasesdb-stamp" file
+		       file_context)
+	      (filecon "/var/lib/misc/postfix\.aliasesdb-stamp\..*" file
+		       file_context)
+
+	      (filecon "/var/lib/postfix" dir file_context)
+	      (filecon "/var/lib/postfix/.*" any file_context)
+
+	      (macro state_file_type_transition_file
+		     ((type ARG1)(class ARG2)(name ARG3))
+		     (call .state.file_type_transition
+			   (ARG1 file ARG2 ARG3)))
+
+	      (blockinherit .file.macro_template_dirs)
+	      (blockinherit .file.macro_template_files)
+	      (blockinherit .file.state.base_template))
+
+       (block trace
+
+	      (block spool
+
+		     (filecon "/var/spool/postfix/trace" dir file_context)
+		     (filecon "/var/spool/postfix/trace/.*" any ())
+
+		     (macro postfix_spool_file_type_transition_file
+			    ((type ARG1))
+			    (call .postfix.spool.file_type_transition
+				  (ARG1 file dir "trace")))
+
+		     (blockinherit .file.spool.postfix.template)))
+
+       (block unit
+
+	      (filecon "/usr/lib/systemd/system/postfix\.service.*" file
+		       file_context)
+	      (filecon "/usr/lib/systemd/system/postfix@.*\.service.*" file
+		       file_context)
+
+	      (blockinherit .file.unit.template)))
+
+(in file.spool
+
+    (block postfix
+
+	   (macro getattr_all_files ((type ARG1))
+		  (allow ARG1 typeattr (file (getattr))))
+
+	   (macro setattr_all_dirs ((type ARG1))
+		  (allow ARG1 typeattr (dir (setattr))))
+
+	   (macro type ((type ARG1))
+		  (typeattributeset typeattr ARG1))
+
+	   (blockinherit file.all_macro_template_dirs)
+	   (blockinherit file.all_macro_template_files)
+	   (blockinherit file.all_macro_template_lnk_files)
+
+	   (typeattribute typeattr)
+
+	   (call file.spool.type (typeattr))
+
+	   (block base_template
+
+		  (blockabstract base_template)
+
+		  (blockinherit .file.spool.base_template)
+
+		  (call .file.spool.postfix.type (file)))
+
+	   (block template
+
+		  (blockabstract template)
+
+		  (blockinherit .file.spool.postfix.base_template)
+		  (blockinherit .file.macro_template_dirs)
+		  (blockinherit .file.macro_template_files))))
+
+(in file.unconfined
+
+    (call .postfix.active.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.bounce.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.cert.cert_file_type_transition_file (typeattr))
+    (call .postfix.conf.conf_file_type_transition_file (typeattr))
+    (call .postfix.corrupt.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.data.data_file_type_transition_file (typeattr))
+    (call .postfix.defer.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.deferred.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.flush.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.hold.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.incoming.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.log.log_file_type_transition_file (typeattr "postfix.log"))
+    (call .postfix.maildrop.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.pid.spool.postfix_spool_file_type_transition_file (typeattr))
+    (call .postfix.private.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.public.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.saved.spool.postfix_spool_file_type_transition_file
+	  (typeattr))
+    (call .postfix.spool.spool_file_type_transition_file (typeattr))
+    (call .postfix.state.state_file_type_transition_file
+	  (typeattr dir "postfix"))
+    (call .postfix.state.state_file_type_transition_file
+	  (typeattr file "postfix.aliasesdb-stamp"))
+    (call .postfix.trace.spool.postfix_spool_file_type_transition_file
+	  (typeattr)))

--- a/src/agent/misc/postfix/postfixanvil.cil
+++ b/src/agent/misc/postfix/postfixanvil.cil
@@ -1,0 +1,23 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block anvil
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (optional postfixanvil_dovecot
+		     (call .dovecot.connectto_subj_unix_stream_sockets
+			   (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/anvil" file file_context))))

--- a/src/agent/misc/postfix/postfixbounce.cil
+++ b/src/agent/misc/postfix/postfixbounce.cil
@@ -1,0 +1,26 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix.bounce
+
+    (blockinherit .agent.template)
+
+    (allow subj self (tcp_socket (create)))
+
+    (call defer.spool.manage_file_dirs (subj))
+    (call defer.spool.manage_file_files (subj))
+
+    (call incoming.spool.readwrite_file_files (subj))
+
+    (call master.agent (subj exec.file))
+    (call master.unix_stream_connect_public (subj))
+
+    (call spool.manage_file_files (subj))
+    (call spool.readwrite_file_dirs (subj))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/bin/bounce" file file_context)))

--- a/src/agent/misc/postfix/postfixcleanup.cil
+++ b/src/agent/misc/postfix/postfixcleanup.cil
@@ -1,0 +1,33 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block cleanup
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self create_tcp_socket)
+
+	   (call hold.spool.addname_file_dirs (subj))
+
+	   (call incoming.spool.manage_file_files (subj))
+	   (call incoming.spool.readwrite_file_dirs (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call smtpd.readwrite_subj_tcp_sockets (subj))
+	   (call smtpd.readwrite_subj_unix_stream_sockets (subj))
+	   (call smtpd.use_subj_fds (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (optional postfixcleanup_opendkimunreservedport
+		     (call .opendkim.nameconnect_port_tcp_sockets (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/cleanup" file file_context))))

--- a/src/agent/misc/postfix/postfixcli.cil
+++ b/src/agent/misc/postfix/postfixcli.cil
@@ -1,0 +1,90 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block cli
+
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self (capability (setgid setuid)))
+	   (allow subj self create_tcp_socket)
+
+	   (call active.spool.deletename_file_dirs (subj))
+
+	   (call common.type (subj))
+
+	   (call conf.manage_file_files (subj))
+	   (call conf.readwrite_file_dirs (subj))
+
+	   (call defer.spool.delete_file_files (subj))
+	   (call defer.spool.deletename_file_dirs (subj))
+
+	   (call deferred.spool.deletename_file_dirs (subj))
+
+	   (call hold.spool.delete_file_files (subj))
+	   (call hold.spool.deletename_file_dirs (subj))
+
+	   (call incoming.spool.delete_file_files (subj))
+	   (call incoming.spool.deletename_file_dirs (subj))
+
+	   (call log.append_file_files (subj))
+	   (call log.create_file_files (subj))
+	   (call log.log_file_type_transition_file (subj "postfix.log"))
+
+	   (call maildrop.spool.manage_file_files (subj))
+	   (call maildrop.spool.readwrite_file_dirs (subj))
+
+	   (call master.readwrite_subj_unix_stream_sockets (subj))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call pipe.readwriteinherited_subj_fifo_files (subj))
+	   (call pipe.use_subj_fds (subj))
+
+	   (call sendmail.readwrite_subj_unix_stream_sockets (subj))
+	   (call sendmail.use_subj_fds (subj))
+	   (call sendmail.mailer.writeinherited_all_fifo_files (subj))
+	   (call sendmail.mailer.use_all_fds (subj))
+
+	   (call .aliases.manage_file_files (subj))
+	   (call .aliases.conf_file_type_transition_file (subj "*"))
+
+	   (call .cert.read_file_files (subj))
+	   (call .cert.traverse_file_pattern.type (subj))
+
+	   (call .file.spool.postfix.getattr_all_files (subj))
+	   (call .file.spool.postfix.list_all_dirs (subj))
+
+	   (call .nss.hosts.type (subj))
+	   (call .nss.passwdgroup.type (subj))
+	   (call .nss.services.type (subj))
+
+	   (call .smtp.msa.nameconnect_port_tcp_sockets (subj))
+	   (call .smtp.nameconnect_port_tcp_sockets (subj))
+
+	   (optional postfixcli_dovecot
+		     (call .dovecot.readwriteinherited_subj_fifo_files (subj))
+		     (call .dovecot.use_subj_fds (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/postalias" file file_context)
+		  (filecon "/usr/bin/postcat" file file_context)
+		  (filecon "/usr/bin/postconf" file file_context)
+		  (filecon "/usr/bin/postdrop" file file_context)
+		  (filecon "/usr/bin/postfix-add-filter" file file_context)
+		  (filecon "/usr/bin/postfix-add-policy" file file_context)
+		  (filecon "/usr/bin/postkick" file file_context)
+		  (filecon "/usr/bin/postlock" file file_context)
+		  (filecon "/usr/bin/postlog" file file_context)
+		  (filecon "/usr/bin/postmap" file file_context)
+		  (filecon "/usr/bin/postqueue" file file_context)
+		  (filecon "/usr/bin/postsuper" file file_context)
+		  (filecon "/usr/bin/posttls-finger" file file_context)
+		  (filecon "/usr/bin/qmqp-sink" file file_context)
+		  (filecon "/usr/bin/qmqp-source" file file_context)
+		  (filecon "/usr/bin/qshape" file file_context)
+		  (filecon "/usr/bin/smtp-sink" file file_context)
+		  (filecon "/usr/bin/smtp-source" file file_context)
+
+		  (call common.exec.type (file)))))

--- a/src/agent/misc/postfix/postfixdiscard.cil
+++ b/src/agent/misc/postfix/postfixdiscard.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block discard
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/discard" file file_context))))

--- a/src/agent/misc/postfix/postfixdnsblog.cil
+++ b/src/agent/misc/postfix/postfixdnsblog.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block dnsblog
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/dnsblog" file file_context))))

--- a/src/agent/misc/postfix/postfixerror.cil
+++ b/src/agent/misc/postfix/postfixerror.cil
@@ -1,0 +1,22 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block error
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call incoming.spool.readwrite_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/error" file file_context))))

--- a/src/agent/misc/postfix/postfixflush.cil
+++ b/src/agent/misc/postfix/postfixflush.cil
@@ -1,0 +1,15 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix.flush
+
+    (blockinherit .agent.template)
+
+    (call master.agent (subj exec.file))
+
+    (call .rbacsep.constrained.type (subj))
+    (call .rbacsep.usefdsource.type (subj))
+
+    (block exec
+
+	   (filecon "/usr/bin/flush" file file_context)))

--- a/src/agent/misc/postfix/postfixfsstone.cil
+++ b/src/agent/misc/postfix/postfixfsstone.cil
@@ -1,0 +1,18 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block fsstone
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/fsstone" file file_context))))

--- a/src/agent/misc/postfix/postfixlocal.cil
+++ b/src/agent/misc/postfix/postfixlocal.cil
@@ -1,0 +1,45 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block local
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call incoming.spool.readwrite_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call spool.manage_file_files (subj))
+	   (call spool.mail_file_type_transition_file (subj "*"))
+
+	   (call .aliases.read_file_files (subj))
+
+	   (call .mail.deletename_file_dirs (subj))
+
+	   (call .nss.services.type (subj))
+
+	   (call .user.home.search_file_pattern.type (subj))
+
+	   (call .user.mail.append_file_files (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/local" file file_context))
+
+	   (block spool
+
+		  (filecon "/var/mail/*.\.lock" file file_context)
+		  (filecon "/var/mail/*.\.lock\..*" file file_context)
+
+		  (macro mail_file_type_transition_file ((type ARG1)(name ARG2))
+			 (call .mail.file_type_transition
+			       (ARG1 file file ARG2)))
+
+		  (blockinherit .file.macro_template_files)
+		  (blockinherit .file.spool.postfix.base_template))))

--- a/src/agent/misc/postfix/postfixmaster.cil
+++ b/src/agent/misc/postfix/postfixmaster.cil
@@ -1,0 +1,135 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (call master.readwrite_subj_unix_stream_sockets (subj))
+    (call master.signal_subj_processes (subj))
+    (call master.subj_type_transition (subj))
+
+    (block master
+
+	   (macro agent ((type ARG1)(type ARG2))
+		  (typetransition subj ARG2 process ARG1)
+		  (call service.exec.type (ARG2))
+		  (call service.type (ARG1)))
+
+	   (macro accept_subj_tcp_sockets ((type ARG1))
+		  (allow ARG1 subj (tcp_socket (accept))))
+
+	   (macro accept_subj_unix_stream_sockets ((type ARG1))
+		  (allow ARG1 subj (unix_stream_socket (accept))))
+
+	   (macro readwrite_subj_tcp_sockets ((type ARG1))
+		  (allow ARG1 subj readwrite_tcp_socket))
+
+	   (macro unix_dgram_send_public ((type ARG1))
+		  (call sendto_subj_unix_dgram_sockets (ARG1))
+		  (call public.spool.search_file_dirs (ARG1))
+		  (call public.spool.write_file_sock_files (ARG1)))
+
+	   (macro unix_stream_connect_private ((type ARG1))
+		  (call connectto_subj_unix_stream_sockets (ARG1))
+		  (call private.spool.search_file_dirs (ARG1))
+		  (call private.spool.write_file_sock_files (ARG1)))
+
+	   (macro unix_stream_connect_public ((type ARG1))
+		  (call connectto_subj_unix_stream_sockets (ARG1))
+		  (call public.spool.search_file_dirs (ARG1))
+		  (call public.spool.write_file_sock_files (ARG1)))
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self
+		  (capability (dac_read_search kill net_bind_service setgid
+					       setuid)))
+	   (allow subj self create_tcp_stream_socket)
+	   (allow subj self (unix_stream_socket (accept connectto listen)))
+
+	   (call service.exec.mapexecute_all_files (subj))
+	   (call service.exec.read_all_files (subj))
+	   (call service.signal_all_processes (subj))
+	   (call service.transition_all_processes (subj))
+
+	   (call common.type (subj))
+
+	   (call pid.spool.manage_file_files (subj))
+	   (call pid.spool.readwrite_file_dirs (subj))
+
+	   (call private.spool.manage_file_sock_files (subj))
+	   (call private.spool.readwrite_file_dirs (subj))
+
+	   (call public.spool.manage_file_sock_files (subj))
+	   (call public.spool.readwrite_file_dirs (subj))
+
+	   (call state.manage_file_files (subj))
+	   (call state.readwrite_file_dirs (subj))
+
+	   (call .net.nodebind_netnode_tcp_sockets (subj))
+
+	   (call .nss.hosts.type (subj))
+	   (call .nss.passwdgroup.type (subj))
+	   (call .nss.services.type (subj))
+
+	   (call .rbacsep.exempttarget.type (subj))
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdtarget.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .smtp.msa.namebind_port_tcp_sockets (subj))
+	   (call .smtp.namebind_port_tcp_sockets (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/master" file file_context)
+
+		  (call common.exec.type (file)))
+
+	      (block service
+
+		     (macro signal_all_processes ((type ARG1))
+			    (allow ARG1 typeattr (process (signal))))
+
+		     (macro transition_all_processes ((type ARG1))
+			    (allow ARG1 typeattr (process (transition))))
+
+		     (macro type ((type ARG1))
+			    (typeattributeset typeattr ARG1))
+
+		     (typeattribute typeattr)
+
+		     (allow typeattr self
+			    (capability (dac_read_search setgid setuid)))
+
+		     (call common.type (typeattr))
+
+		     (call master.accept_subj_unix_stream_sockets (typeattr))
+		     (call master.readwrite_subj_unix_stream_sockets (typeattr))
+		     (call master.readwriteinherited_subj_fifo_files (typeattr))
+		     (call master.sigchld_subj_processes (typeattr))
+		     (call master.use_subj_fds (typeattr))
+
+		     (call pid.spool.manage_file_files (typeattr))
+		     (call pid.spool.readwrite_file_dirs (typeattr))
+
+		     (call .nss.hosts.type (typeattr))
+		     (call .nss.passwdgroup.type (typeattr))
+
+		     (block exec
+
+			    (macro mapexecute_all_files ((type ARG1))
+				   (allow ARG1 typeattr mapexecute_file))
+
+			    (macro read_all_files ((type ARG1))
+				   (allow ARG1 typeattr read_file))
+
+			    (macro type ((type ARG1))
+				   (typeattributeset typeattr ARG1))
+
+			    (typeattribute typeattr)
+
+			    (call common.exec.type (typeattr))))))
+
+(in postfix.common
+
+    (call master.unix_dgram_send_public (typeattr)))

--- a/src/agent/misc/postfix/postfixpickup.cil
+++ b/src/agent/misc/postfix/postfixpickup.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block pickup
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call maildrop.spool.delete_file_files (subj))
+	   (call maildrop.spool.deletename_file_dirs (subj))
+	   (call maildrop.spool.read_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/pickup" file file_context))))

--- a/src/agent/misc/postfix/postfixpipe.cil
+++ b/src/agent/misc/postfix/postfixpipe.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block pipe
+
+	   (blockinherit .agent.template)
+
+	   (call incoming.spool.readwrite_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/pipe" file file_context))))

--- a/src/agent/misc/postfix/postfixpostlogd.cil
+++ b/src/agent/misc/postfix/postfixpostlogd.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block postlogd
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call log.append_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.readwrite_subj_unix_dgram_sockets (subj))
+
+	   (call .log.search_file_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/postlogd" file file_context))))

--- a/src/agent/misc/postfix/postfixpostscreen.cil
+++ b/src/agent/misc/postfix/postfixpostscreen.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block postscreen
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/postscreen" file file_context))))

--- a/src/agent/misc/postfix/postfixproxymap.cil
+++ b/src/agent/misc/postfix/postfixproxymap.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block proxymap
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/proxymap" file file_context))))

--- a/src/agent/misc/postfix/postfixqmgr.cil
+++ b/src/agent/misc/postfix/postfixqmgr.cil
@@ -1,0 +1,36 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block qmgr
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call active.spool.delete_file_files (subj))
+	   (call active.spool.readwrite_file_dirs (subj))
+
+	   (call bounce.spool.getattr_file_files (subj))
+
+	   (call defer.spool.delete_file_files (subj))
+	   (call defer.spool.deletename_file_dirs (subj))
+
+	   (call deferred.spool.manage_file_dirs (subj))
+	   (call deferred.spool.setattr_file_files (subj))
+
+	   (call incoming.spool.manage_file_files (subj))
+	   (call incoming.spool.readwrite_file_dirs (subj))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+
+		  (filecon "/usr/bin/nqmgr" file file_context)
+		  (filecon "/usr/bin/oqmgr" file file_context)
+		  (filecon "/usr/bin/qmgr" file file_context))))

--- a/src/agent/misc/postfix/postfixqmqpd.cil
+++ b/src/agent/misc/postfix/postfixqmqpd.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block qmqpd
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/qmqpd" file file_context))))

--- a/src/agent/misc/postfix/postfixrmail.cil
+++ b/src/agent/misc/postfix/postfixrmail.cil
@@ -1,0 +1,14 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block rmail
+
+	   (blockinherit .hybrid.agent.template)
+
+	   (call .rbacsep.constrained.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/rmail" file file_context))))

--- a/src/agent/misc/postfix/postfixscache.cil
+++ b/src/agent/misc/postfix/postfixscache.cil
@@ -1,0 +1,23 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block scache
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call smtp.readwrite_subj_tcp_sockets (subj))
+	   (call smtp.readwrite_subj_unix_stream_sockets (subj))
+	   (call smtp.use_subj_fds (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/scache" file file_context))))

--- a/src/agent/misc/postfix/postfixsendmail.cil
+++ b/src/agent/misc/postfix/postfixsendmail.cil
@@ -1,0 +1,87 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block sendmail
+
+	   (blockinherit .hybrid.agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call cli.signal_subj_processes (subj))
+	   (call cli.subj_type_transition (subj))
+
+	   (call common.type (subj))
+
+	   (call mailer.readwrite_all_unix_stream_sockets (subj))
+	   (call mailer.use_all_fds (subj))
+
+	   (call mailer.tmp.readwriteinherited_all_files (subj))
+
+	   (call master.readwriteinherited_subj_fifo_files (subj))
+	   (call master.use_subj_fds (subj))
+
+	   (call pipe.readwriteinherited_subj_fifo_files (subj))
+	   (call pipe.use_subj_fds (subj))
+
+	   (call .nss.hosts.type (subj))
+	   (call .nss.passwdgroup.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.exemptsource.type (subj))
+
+	   (call .sys.home.list_file_dirs (subj))
+
+	   (optional postfixsendmail_dovecot
+		     (call .dovecot.readwrite_subj_unix_stream_sockets (subj))
+		     (call .dovecot.readwriteinherited_subj_fifo_files (subj))
+		     (call .dovecot.spool.readwriteinherited_file_files (subj))
+		     (call .dovecot.use_subj_fds (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/sendmail" file file_context)
+
+		  (call common.exec.type (file)))
+
+	   (block mailer
+
+		  (macro readwrite_all_unix_stream_sockets ((type ARG1))
+			 (allow ARG1 typeattr readwrite_unix_stream_socket))
+
+		  (macro role ((role ARG1))
+			 (roleattributeset roleattr ARG1))
+
+		  (macro type ((type ARG1))
+			 (typeattributeset typeattr ARG1))
+
+		  (macro use_all_fds ((type ARG1))
+			 (allow ARG1 typeattr (fd (use))))
+
+		  (macro writeinherited_all_fifo_files ((type ARG1))
+			 (allow ARG1 typeattr writeinherited_fifo_file))
+
+		  (roleattribute roleattr)
+		  (typeattribute typeattr)
+
+		  (call cli.role (roleattr))
+
+		  (call sendmail.signal_subj_processes (typeattr))
+		  (call sendmail.subj_type_transition (typeattr))
+		  (call sendmail.role (roleattr))
+
+		  (block tmp
+
+			 (macro readwriteinherited_all_files ((type ARG1))
+				(allow ARG1 typeattr
+				       readwriteinherited_file))
+
+			 (macro type ((type ARG1))
+				(typeattributeset typeattr ARG1))
+
+			 (typeattribute typeattr)))))
+
+(in sys.tmp
+
+    (call .postfix.sendmail.mailer.tmp.type (file)))

--- a/src/agent/misc/postfix/postfixshowq.cil
+++ b/src/agent/misc/postfix/postfixshowq.cil
@@ -1,0 +1,22 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block showq
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .file.spool.postfix.list_all_dirs (subj))
+	   (call .file.spool.postfix.read_all_files (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/showq" file file_context))))

--- a/src/agent/misc/postfix/postfixsmtp.cil
+++ b/src/agent/misc/postfix/postfixsmtp.cil
@@ -1,0 +1,39 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block smtp
+
+	   (macro readwrite_subj_tcp_sockets ((type ARG1))
+		  (allow ARG1 subj readwrite_tcp_socket))
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self create_tcp_socket)
+
+	   (call incoming.spool.readwrite_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+
+	   (call .cert.read_file_files (subj))
+	   (call .cert.traverse_file_pattern.type (subj))
+
+	   (call .net.nodebind_netnode_tcp_sockets (subj))
+
+	   (call .nss.services.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .smtp.msa.nameconnect_port_tcp_sockets (subj))
+	   (call .smtp.nameconnect_port_tcp_sockets (subj))
+
+	   (optional postfixsmtp_dovecot
+		     (call .dovecot.connectto_subj_unix_stream_sockets (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/lmtp" file file_context)
+		  (filecon "/usr/bin/smtp" file file_context))))

--- a/src/agent/misc/postfix/postfixsmtpd.cil
+++ b/src/agent/misc/postfix/postfixsmtpd.cil
@@ -1,0 +1,47 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block smtpd
+
+	   (macro readwrite_subj_tcp_sockets ((type ARG1))
+		  (allow ARG1 subj readwrite_tcp_socket))
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self create_tcp_socket)
+
+	   (call cert.list_file_dirs (subj))
+	   (call cert.read_file_files (subj))
+
+	   (call master.agent (subj exec.file))
+	   (call master.accept_subj_tcp_sockets (subj))
+	   (call master.readwrite_subj_tcp_sockets (subj))
+	   (call master.unix_stream_connect_private (subj))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call .aliases.read_file_files (subj))
+
+	   (call .cert.read_file_files (subj))
+	   (call .cert.traverse_file_pattern.type (subj))
+
+	   (call .crypto.read_sysctlfile_pattern.type (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (call .xattr.getattr_fs_pattern.type (subj))
+
+	   (optional postfixsmtpd_certbot
+		     (call .certbot.conf.read_file_pattern.type (subj)))
+
+	   (optional postfixsmtpd_dovecot
+		     (call .dovecot.connectto_subj_unix_stream_sockets (subj)))
+
+	   (optional postfixsmtpd_opendkimunreservedport
+		     (call .opendkim.nameconnect_port_tcp_sockets (subj)))
+
+	   (block exec
+
+		  (filecon "/usr/bin/smtpd" file file_context))))

--- a/src/agent/misc/postfix/postfixspawn.cil
+++ b/src/agent/misc/postfix/postfixspawn.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block spawn
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/spawn" file file_context))))

--- a/src/agent/misc/postfix/postfixtlsmgr.cil
+++ b/src/agent/misc/postfix/postfixtlsmgr.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block tlsmgr
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call state.manage_file_files (subj))
+	   (call state.readwrite_file_dirs (subj))
+
+	   (call .random.read_nodedev_chr_files (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/tlsmgr" file file_context))))

--- a/src/agent/misc/postfix/postfixtlsproxy.cil
+++ b/src/agent/misc/postfix/postfixtlsproxy.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block tlsproxy
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/tlsproxy" file file_context))))

--- a/src/agent/misc/postfix/postfixtrivialrewrite.cil
+++ b/src/agent/misc/postfix/postfixtrivialrewrite.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block trivialrewrite
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/trivial-rewrite" file file_context))))

--- a/src/agent/misc/postfix/postfixverify.cil
+++ b/src/agent/misc/postfix/postfixverify.cil
@@ -1,0 +1,24 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block verify
+
+	   (blockinherit .agent.template)
+
+	   (allow subj self (tcp_socket (create)))
+
+	   (call master.agent (subj exec.file))
+	   (call master.unix_stream_connect_private (subj))
+	   (call master.unix_stream_connect_public (subj))
+
+	   (call state.manage_file_files (subj))
+	   (call state.readwrite_file_dirs (subj))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/verify" file file_context))))

--- a/src/agent/misc/postfix/postfixvirtual.cil
+++ b/src/agent/misc/postfix/postfixvirtual.cil
@@ -1,0 +1,17 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(in postfix
+
+    (block virtual
+
+	   (blockinherit .agent.template)
+
+	   (call master.agent (subj exec.file))
+
+	   (call .rbacsep.constrained.type (subj))
+	   (call .rbacsep.usefdsource.type (subj))
+
+	   (block exec
+
+		  (filecon "/usr/bin/virtual" file file_context))))

--- a/src/agent/misc/systemd/systemdsystemctl.cil
+++ b/src/agent/misc/systemd/systemdsystemctl.cil
@@ -59,7 +59,9 @@
 	   (call .cgroup.list_fs_dirs (subj))
 	   (call .cgroup.read_fs_files (subj))
 
-	   (call .conf.list_file_dirs (subj))
+	   ;; update-rc.d: /etc/rc.d
+	   (call .conf.manage_file_lnk_files (subj))
+	   (call .conf.readwrite_file_dirs (subj))
 
 	   (call .crypto.read_sysctlfile_pattern.type (subj))
 

--- a/src/agent/useragent/e/emacs.cil
+++ b/src/agent/useragent/e/emacs.cil
@@ -276,7 +276,7 @@
 		 (call .p11kit.data.map_file_files (subj))
 		 (call .p11kit.read_file_pattern.type (subj)))
 
-       (optional emacs_postfix
+       (optional emacs_postfixsendmail
 		 (call .postfix.sendmail.mailer.type (subj)))
 
        (optional emacs_sudo

--- a/src/file/conffile/aliasesconffile.cil
+++ b/src/file/conffile/aliasesconffile.cil
@@ -1,0 +1,19 @@
+;; SPDX-FileCopyrightText: © 2021 Dominick Grift <dominick.grift@defensec.nl>
+;; SPDX-License-Identifier: Unlicense
+
+(block aliases
+
+       (filecon "/etc/aliases" file file_context)
+       (filecon "/etc/aliases\..*" file file_context)
+
+       (macro conf_file_type_transition_file ((type ARG1)(name ARG2))
+	      (call .conf.file_type_transition
+		    (ARG1 file file ARG2)))
+
+       (blockinherit .file.conf.base_template)
+       (blockinherit .file.macro_template_files))
+
+(in file.unconfined
+
+    (call .aliases.conf_file_type_transition_file (typeattr "aliases"))
+    (call .aliases.conf_file_type_transition_file (typeattr "aliases.db")))

--- a/src/file/userfile/usertmpfile.cil
+++ b/src/file/userfile/usertmpfile.cil
@@ -53,4 +53,7 @@
 		  (call .tmp.file_type_transition
 			(ARG1 file ARG2 ARG3)))
 
-	   (blockinherit .file.user.tmp.template)))
+	   (blockinherit .file.user.tmp.template)
+
+	   (optional usertmpfile_postfixsendmail
+		     (call .postfix.sendmail.mailer.tmp.type (file)))))

--- a/src/user/unprivuser.cil
+++ b/src/user/unprivuser.cil
@@ -229,6 +229,10 @@
 	      (call .polkit.check.role (role))
 	      (call .polkit.ttyagent.role (role)))
 
+    (optional unprivuser_postfixsendmail
+	      (call .postfix.sendmail.mailer.type (subj))
+	      (call .postfix.sendmail.mailer.role (role)))
+
     (optional unprivuser_qemu
 	      (call .qemu.data.list_file_dirs (subj))
 	      (call .qemu.data.read_file_files (subj))

--- a/src/user/wheeluser.cil
+++ b/src/user/wheeluser.cil
@@ -77,6 +77,9 @@
 		 (call .polkit.check.role (role))
 		 (call .polkit.ttyagent.role (role)))
 
+       (optional wheeluser_postfixsendmail
+		 (call .postfix.sendmail.mailer.role (role)))
+
        (optional wheeluser_qemu
 		 (call .qemu.bridgehelper.role (role)))
 


### PR DESCRIPTION
- rsync style
- makefile: adds equiv for postfix sbin
- mysql utils runs secure-installation which runs client etc
- add ppp conf to network conf file
- makefile postfix chroot
- useradd: checks /bin/nologin (probably not in /etc/shells)
- makefile fixes postfix chroot
- systemctl: sysvinit related
- postfix
